### PR TITLE
[#169] 모임 상태 자동 변경 프로세스 구현

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/crew/repository/CrewRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/repository/CrewRepository.java
@@ -1,11 +1,13 @@
 package com.prgrms.mukvengers.domain.crew.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,7 +17,7 @@ public interface CrewRepository extends JpaRepository<Crew, Long> {
 
 	// N+1 발생
 	@Query(value = """
-		SELECT c 
+		SELECT c
 		FROM Crew c
 		JOIN FETCH c.store s
 		WHERE s.placeId = :placeId
@@ -27,4 +29,13 @@ public interface CrewRepository extends JpaRepository<Crew, Long> {
 		"SELECT * FROM crew c "
 			+ "WHERE ST_DISTANCE_SPHERE(:location, c.location) < :distance AND c.status = 'RECRUITING'")
 	List<Crew> findAllByLocation(@Param("location") Point location, @Param("distance") int distance);
+
+	@Modifying
+	@Query(value = """
+		UPDATE Crew c
+		SET c.status = 'FINISH'
+		WHERE c.status != 'FINISH' AND c.promiseTime < :time
+		""")
+	int updateStatusAll(@Param("time")LocalDateTime now);
+
 }

--- a/src/main/java/com/prgrms/mukvengers/global/scheduler/Scheduler.java
+++ b/src/main/java/com/prgrms/mukvengers/global/scheduler/Scheduler.java
@@ -1,0 +1,26 @@
+package com.prgrms.mukvengers.global.scheduler;
+
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class Scheduler {
+
+	private final CrewRepository crewRepository;
+
+	@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+	@Transactional
+	public void changStatusOvertimeCrew() {
+		crewRepository.updateStatusAll(LocalDateTime.now());
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/repository/CrewRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/repository/CrewRepositoryTest.java
@@ -2,6 +2,7 @@ package com.prgrms.mukvengers.domain.crew.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -45,5 +46,14 @@ class CrewRepositoryTest extends RepositoryTest {
 
 		assertThat(savedCrews).hasSize(crews.size());
 
+	}
+
+	@Test
+	@DisplayName("[성공] 시간이 지난 모임을 찾아 종료시킨다.")
+	void updateStatusAll_success() {
+
+		int result = crewRepository.updateStatusAll(LocalDateTime.now());
+
+		assertThat(result).isEqualTo(20); // 만들어져 있는 크루 전부 지워짐
 	}
 }


### PR DESCRIPTION
### 🌱 작업 사항 
- 시간이 지난 모임 삭제 메서드를 추가했습니다.
  - 쿼리는 테스트 코드를 통해서 확인 했습니다.
  - [feat(Crew): 시간이 지난 모임 삭제 메서드 추가](https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-BE/commit/96433f2a1b89e0c64c5a054d23fccfebfb205888)

- Spring에서 제공하는 @Scheduled을 통해서 스케줄링 작업을 구현했습니다.
  - 매시각 정각에 앞서 만든 `시간이 지난 모임 삭제 메서드`를 실행합니다.
  - 스케줄링 작업은  정각에 실제 동작하는지 직접 확인 했습니다. 
  - [feat(Schedule): 매일 1시간 마다 동작하는 스케줄 작성](https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-BE/commit/b86e9e1d10a5c4b81b577abf2da27c968e88829d)

<img width="855" alt="스크린샷 2023-03-28 오후 4 00 46" src="https://user-images.githubusercontent.com/99165624/228157230-e0f2e523-c77c-4b7e-b87e-6bab4cfacc1d.png">

- [참고자료] [Scheduler 사용해보기](https://data-make.tistory.com/699)
### ❓ 리뷰 포인트
- `updateStatusAll` 라는 메서드 명이 괜찮은가요..?
- 주기는 크루가 많지 않다는 가정하에` 1시간`으로 설정 했는데 어떻게 가져가면 좋을지 의견 부탁드립니다.
  - 개인적으로는 `10분 ~ 1시간 사이`로 가져가도 괜찮을 것 같다고 생각합니다. 
  - 왜냐하면 한번에 많이 하게 되면 `batch size`도 고려해야하기 때문입니다. 
  - 짧게 여러번 가져가도록 **`일단`** 구현하고 `이슈에 따라 적절히 변경`하는 것은 어떻게 생각하시나요..?
### 🦄 관련 이슈
resolves #169 



