### PR TITLE
[#174] 무중단 배포 적용

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -87,7 +87,6 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script: |
-            sudo docker rm -f $(docker ps -qa)
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
             chmod 777 ./deploy.sh
             ./deploy.sh

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -6,6 +6,10 @@ on:
       - develop
       - 'fix/**'
 
+  pull-request:
+    branches:
+      - develop  #TODO 무중단배포 완료 후 merge할 때 제거
+
 # 권한 설정
 permissions:
   contents: read
@@ -43,7 +47,7 @@ jobs:
           docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
 
       # 환경 변수 파일 서버로 전달하기(복사 후 붙여넣기)
-      - name: Send to Environment
+      - name: Send env file
         uses: appleboy/scp-action@master
         with:
           username: ubuntu
@@ -53,7 +57,7 @@ jobs:
           target: "/home/ubuntu"
 
       # 도커 컴포즈 설정 파일 서버로 전달하기(복사 후 붙여넣기)
-      - name: Send to Docker-Compose
+      - name: Send docker-compose.yml
         uses: appleboy/scp-action@master
         with:
           username: ubuntu
@@ -61,6 +65,17 @@ jobs:
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           port: 22
           source: "./docker-compose.yml"
+          target: "/home/ubuntu/"
+
+      # deploy.sh 파일 서버로 전달하기(복사 후 붙여넣기)
+      - name: Send deploy.sh
+        uses: appleboy/scp-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.EC2_HOST }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          port: 22
+          source: "./deploy.sh"
           target: "/home/ubuntu/"
 
       # 도커 컴포즈 실행하기
@@ -74,6 +89,6 @@ jobs:
           script: |
             sudo docker rm -f $(docker ps -qa)
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
-            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_NGINX_REPO }}
-            docker-compose up -d
+            chmod 777 ./deploy.sh
+            ./deploy.sh
             docker image prune -f

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -6,10 +6,6 @@ on:
       - develop
       - 'fix/**'
 
-  pull_request:
-    branches:
-      - develop  #TODO 무중단배포 완료 후 merge할 때 제거
-
 # 권한 설정
 permissions:
   contents: read

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -6,7 +6,7 @@ on:
       - develop
       - 'fix/**'
 
-  pull-request:
+  pull_request:
     branches:
       - develop  #TODO 무중단배포 완료 후 merge할 때 제거
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+if [ $(docker ps | grep -c "db") -eq 0 ]; then
+  echo "### Starting database ###"
+  docker-compose up -d db
+else
+  echo "db is already running"
+fi
+
+echo
+echo
+
+if [ $(docker ps | grep -c "redis") -eq 0 ]; then
+  echo "### Starting redis ###"
+  docker-compose up -d redis
+else
+  echo "redis is already running"
+fi
+
+APP_NAME=web
+
+IS_GREEN=$(docker ps | grep green) # 현재 실행중인 App이 blue인지 확인
+DEFAULT_CONF=" /etc/nginx/nginx.conf"
+
+if [ -z $IS_GREEN  ];then # blue라면
+
+  echo "### BLUE => GREEN ###"
+
+  echo "1. get green image"
+  docker-compose pull green # 이미지 받아서
+
+  echo "2. green container up"
+  docker-compose up -d green # 컨테이너 실행
+
+  while [ 1 = 1 ]; do
+  echo "3. green health check..."
+  sleep 3
+
+  REQUEST=$(curl http://127.0.0.1:8080) # green으로 request
+    if [ -n "$REQUEST" ]; then # 서비스 가능하면 health check 중지
+            echo "health check success"
+            break ;
+            fi
+  done;
+
+  echo "4. reload nginx"
+  sudo cp /etc/nginx/nginx.green.conf /etc/nginx/nginx.conf
+  sudo nginx -s rel
+
+  echo "5. blue container down"
+  docker-compose stop blue
+else
+
+	echo "### GREEN => BLUE ###"
+
+  echo "1. get blue image"
+  docker-compose pull blue
+
+  echo "2. blue container up"
+  docker-compose up -d blue
+
+  while [ 1 = 1 ]; do
+    echo "3. blue health check..."
+    sleep 3
+    REQUEST=$(curl http://127.0.0.1:8081) # blue로 request
+
+    if [ -n "$REQUEST" ]; then # 서비스 가능하면 health check 중지
+      echo "health check success"
+      break ;
+    fi
+  done;
+
+  echo "4. reload nginx"
+  sudo cp /etc/nginx/nginx.blue.conf /etc/nginx/nginx.conf
+  sudo nginx -s reload
+
+  echo "5. green container down"
+  docker-compose stop green
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,8 +50,7 @@ if [ -z $IS_GREEN  ];then # blue라면
   echo "5. blue container down"
   docker-compose stop blue
 else
-
-	echo "### GREEN => BLUE ###"
+  echo "### GREEN => BLUE ###"
 
   echo "1. get blue image"
   docker-compose pull blue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,13 +22,35 @@ services:
     volumes:
       - ./data/redis:/data
 
-  web:
-    container_name: web
+  green:
+    container_name: green
     image: kiseo/kkini
-    expose:
-      - 8080
     ports:
-      - 8080:8080
+      - "8080:8080"
+    environment:
+      MY_SERVER: ${MY_SERVER}
+      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
+      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
+      KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI}
+      REDIS_HOST: ${REDIS_HOST}
+      REDIS_PORT: ${REDIS_PORT}
+      ACTIVE_PROFILE: ${ACTIVE_PROFILE}
+      SLACK_WEBHOOK: ${SLACK_WEBHOOK}
+
+  blue:
+    container_name: blue
+    image: kiseo/kkini
+    ports:
+      - "8081:8080"
     environment:
       MY_SERVER: ${MY_SERVER}
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}


### PR DESCRIPTION
### 🌱 작업 사항 
- blue/green 방식의 무중단 배포 적용

### ❓ 리뷰 포인트
- 기존의 github action에서는 docker-compose up -d로 컴포즈에 등록된 모든 컨테이너를 한방에 실행했습니다.
하지만 현재 `docker-compose.yml`을 보시면 `blue(8081포트)/green(8080포트)`로 springboot 이미지가 두 개 등록되어 있어서, 
`deploy.sh`에 작성한 배포 스크립트를 실행시키는 방식으로 명령어를 변경했습니다.

`deploy.sh`: 
- db와 redis가 중지상태면 실행시킵니다. 
- 이후 현재 실행중인 컨테이너를 조회합니다.  `$(docker ps | grep green)` 
간단히 설명하고자 현재  **blue 컨테이너**가 **실행중**인 상태라고 하겠습니다.
- CI된 SpringBoot 이미지는 Docker hub에 저장됩니다. 이 이미지를  EC2의 docker에서 **green** 으로 pull 받고 실행시킵니다.
- **green**  컨테이너 실행 후 SpringBoot가 정상 실행되어 health check가 종료되면 `nginx.conf`의 내용을 nginx.blue.conf에서 **nginx.green.conf** 로 변경합니다(각각의 nginx는 443포트로 들어오는 요청을 8081, 8080 포트로 보내줍니다). 
- **blue** 컨테이너를 종료합니다.
- 이제 **green**이 실행중이므로 바로 다음 deploy에서는 **blue**에 업데이트가 되며 nginx.blue.conf을 사용하게 됩니다.
- 참고 링크: https://wkddntjr1123.github.io/project/devrank4/
### 🦄 관련 이슈
- resolves #174 
