### PR TITLE
[#179] UserProfileResponse mannerScore 타입 변경

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/dto/response/UserProfileResponse.java
@@ -8,6 +8,6 @@ public record UserProfileResponse(
 	Integer leaderCount,
 	Integer crewCount,
 	Integer tasteScore,
-	Double mannerScore
+	String mannerScore
 ) {
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
@@ -117,8 +117,7 @@ class ProposalControllerTest extends ControllerTest {
 							fieldWithPath("data.user.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.user.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.user.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.user.mannerScore").type(NUMBER).description("매너 온도"),
-							fieldWithPath("data.user.mannerScore").type(NUMBER).description("매너 온도"))
+							fieldWithPath("data.user.mannerScore").type(STRING).description("매너 온도"))
 						.build()
 				)
 			));
@@ -150,7 +149,7 @@ class ProposalControllerTest extends ControllerTest {
 							fieldWithPath("data.responses.[].user.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.responses.[].user.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.responses.[].user.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.responses.[].user.mannerScore").type(NUMBER).description("매너 온도"),
+							fieldWithPath("data.responses.[].user.mannerScore").type(STRING).description("매너 온도"),
 							fieldWithPath("data.responses.[].id").type(NUMBER).description("신청서 아이디"),
 							fieldWithPath("data.responses.[].content").type(STRING).description("신청서 내용"),
 							fieldWithPath("data.responses.[].status").type(STRING).description("신청서 상태"),
@@ -220,8 +219,7 @@ class ProposalControllerTest extends ControllerTest {
 							fieldWithPath("data.responses.[].user.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.responses.[].user.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.responses.[].user.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.responses.[].user.mannerScore").type(NUMBER).description("매너 온도"),
-							fieldWithPath("data.responses.[].user.mannerScore").type(NUMBER).description("매너 온도"),
+							fieldWithPath("data.responses.[].user.mannerScore").type(STRING).description("매너 온도"),
 							fieldWithPath("data.responses.[].id").type(NUMBER).description("신청서 아이디"),
 							fieldWithPath("data.responses.[].content").type(STRING).description("신청서 내용"),
 							fieldWithPath("data.responses.[].status").type(STRING).description("신청서 상태"),

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
@@ -263,7 +263,7 @@ class ProposalServiceImplTest extends ServiceTest {
 			.hasFieldOrPropertyWithValue("leaderCount", user.getLeaderCount())
 			.hasFieldOrPropertyWithValue("crewCount", user.getCrewCount())
 			.hasFieldOrPropertyWithValue("tasteScore", user.getTasteScore())
-			.hasFieldOrPropertyWithValue("mannerScore", user.getMannerScore());
+			.hasFieldOrPropertyWithValue("mannerScore", String.valueOf(user.getMannerScore()));
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
@@ -173,7 +173,7 @@ class ReviewControllerTest extends ControllerTest {
 							fieldWithPath("data.reviewee.leaderCount").type(NUMBER).description("리뷰이의 리더 횟수"),
 							fieldWithPath("data.reviewee.crewCount").type(NUMBER).description("리뷰이의 밥모임 참여한 횟수"),
 							fieldWithPath("data.reviewee.tasteScore").type(NUMBER).description("리뷰이의 맛잘알 점수"),
-							fieldWithPath("data.reviewee.mannerScore").type(NUMBER).description("리뷰이의 매너 점수"),
+							fieldWithPath("data.reviewee.mannerScore").type(STRING).description("리뷰이의 매너 점수"),
 
 							fieldWithPath("data.crew.currentMember").type(NULL).description("밥모임의 아이디"),
 							fieldWithPath("data.crew.id").type(NUMBER).description("밥모임의 아이디"),
@@ -239,7 +239,7 @@ class ReviewControllerTest extends ControllerTest {
 								.description("리뷰를 작성하고자 하는 사용자의 밥모임 참여 횟수"),
 							fieldWithPath("data.content.[].reviewer.tasteScore").type(NUMBER)
 								.description("리뷰를 작성하고자 하는 사용자의 맛잘알 점수"),
-							fieldWithPath("data.content.[].reviewer.mannerScore").type(NUMBER)
+							fieldWithPath("data.content.[].reviewer.mannerScore").type(STRING)
 								.description("리뷰를 작성하고자 하는 사용자의 매너 온도 점수"),
 
 							fieldWithPath("data.content.[].reviewee.id").type(NUMBER).description("리뷰 남기고자하는 사용자의 아이디"),
@@ -255,7 +255,7 @@ class ReviewControllerTest extends ControllerTest {
 								.description("리뷰 남기고자하는 사용자의 밥모임 참여 횟수"),
 							fieldWithPath("data.content.[].reviewee.tasteScore").type(NUMBER)
 								.description("리뷰 남기고자하는 사용자의 맛잘알 점수"),
-							fieldWithPath("data.content.[].reviewee.mannerScore").type(NUMBER)
+							fieldWithPath("data.content.[].reviewee.mannerScore").type(STRING)
 								.description("리뷰 남기고자하는 사용자의 매너 온도 점수"),
 
 							fieldWithPath("data.content.[].crew.id").type(NUMBER).description("리뷰하고자하는 밥 모임 아이디"),
@@ -346,7 +346,7 @@ class ReviewControllerTest extends ControllerTest {
 								.description("리뷰를 작성하고자 하는 사용자의 밥모임 참여 횟수"),
 							fieldWithPath("data.content.[].reviewer.tasteScore").type(NUMBER)
 								.description("리뷰를 작성하고자 하는 사용자의 맛잘알 점수"),
-							fieldWithPath("data.content.[].reviewer.mannerScore").type(NUMBER)
+							fieldWithPath("data.content.[].reviewer.mannerScore").type(STRING)
 								.description("리뷰를 작성하고자 하는 사용자의 매너 온도 점수"),
 
 							fieldWithPath("data.content.[].reviewee.id").type(NUMBER).description("리뷰 남기고자하는 사용자의 아이디"),
@@ -362,7 +362,7 @@ class ReviewControllerTest extends ControllerTest {
 								.description("리뷰 남기고자하는 사용자의 밥모임 참여 횟수"),
 							fieldWithPath("data.content.[].reviewee.tasteScore").type(NUMBER)
 								.description("리뷰 남기고자하는 사용자의 맛잘알 점수"),
-							fieldWithPath("data.content.[].reviewee.mannerScore").type(NUMBER)
+							fieldWithPath("data.content.[].reviewee.mannerScore").type(STRING)
 								.description("리뷰 남기고자하는 사용자의 매너 온도 점수"),
 
 							fieldWithPath("data.content.[].crew.id").type(NUMBER).description("리뷰하고자하는 밥 모임 아이디"),

--- a/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
@@ -55,7 +55,7 @@ class UserControllerTest extends ControllerTest {
 							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도"))
+							fieldWithPath("data.mannerScore").type(STRING).description("매너 온도"))
 						.build()
 				))
 			);
@@ -93,7 +93,7 @@ class UserControllerTest extends ControllerTest {
 							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도"))
+							fieldWithPath("data.mannerScore").type(STRING).description("매너 온도"))
 						.build()
 				))
 			);
@@ -134,7 +134,7 @@ class UserControllerTest extends ControllerTest {
 							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도"))
+							fieldWithPath("data.mannerScore").type(STRING).description("매너 온도"))
 						.build()
 				))
 			);

--- a/src/test/java/com/prgrms/mukvengers/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/service/UserServiceTest.java
@@ -60,7 +60,7 @@ class UserServiceTest extends ServiceTest {
 				.hasFieldOrPropertyWithValue("leaderCount", 0)
 				.hasFieldOrPropertyWithValue("crewCount", 0)
 				.hasFieldOrPropertyWithValue("tasteScore", 0)
-				.hasFieldOrPropertyWithValue("mannerScore", 36.5)
+				.hasFieldOrPropertyWithValue("mannerScore", "36.5")
 			;
 		}
 


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 매너 온도 관련된 에러가 파싱 과정에서 생긴다고 판단하여 기존 Double에서 String 타입으로 변경하였습니다.
- UserProfileReponse mannerScore 타입 Double -> String
- 관련된 테스트 코드 일괄 수정

### 🦄 관련 이슈
resolves #179 


