### PR TITLE
[#186] redirectUri에 한글이 들어가면 에러 터지는 문제 해결

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/api/ProposalController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/api/ProposalController.java
@@ -1,5 +1,6 @@
 package com.prgrms.mukvengers.domain.proposal.api;
 
+import static org.springframework.http.HttpStatus.*;
 import static org.springframework.http.MediaType.*;
 
 import java.net.URI;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -119,15 +121,14 @@ public class ProposalController {
 	 * @return
 	 */
 	@PatchMapping(value = "/proposals/{proposalId}", consumes = APPLICATION_JSON_VALUE)
-	public ResponseEntity<Void> changeProposalStatus
+	@ResponseStatus(NO_CONTENT)
+	public void changeProposalStatus
 	(
 		@PathVariable Long proposalId,
 		@RequestBody @Valid UpdateProposalRequest proposalRequest,
 		@AuthenticationPrincipal JwtAuthentication user
 	) {
 		proposalService.updateProposalStatus(proposalRequest, user.id(), proposalId);
-
-		return ResponseEntity.ok().build();
 	}
 
 	@DeleteMapping(value = "/proposals/{proposalId}")

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationFailureHandler.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationFailureHandler.java
@@ -1,8 +1,10 @@
 package com.prgrms.mukvengers.global.security.oauth.handler;
 
 import static com.prgrms.mukvengers.global.security.oauth.repository.HttpCookieOAuthAuthorizationRequestRepository.*;
+import static java.nio.charset.StandardCharsets.*;
 
 import java.io.IOException;
+import java.net.URLDecoder;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -31,10 +33,11 @@ public class OAuthAuthenticationFailureHandler
 		AuthenticationException exception) throws IOException {
 		String redirectUrl = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
 			.map(Cookie::getValue)
+			.map(cookie -> URLDecoder.decode(cookie, UTF_8))
 			.orElse(DEFAULT_TARGET_URL);
 
 		String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
-			.queryParam("error", exception.getMessage())
+			.queryParam("error", exception.getMessage()) // TODO: exception.getMessage() -> error code
 			.build().toUriString();
 
 		httpCookieOAuthAuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/repository/HttpCookieOAuthAuthorizationRequestRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/repository/HttpCookieOAuthAuthorizationRequestRepository.java
@@ -1,6 +1,9 @@
 package com.prgrms.mukvengers.global.security.oauth.repository;
 
+import static java.nio.charset.StandardCharsets.*;
 import static org.springframework.util.StringUtils.*;
+
+import java.net.URLEncoder;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -37,6 +40,7 @@ public class HttpCookieOAuthAuthorizationRequestRepository implements
 			CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
 		String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
 		if (hasText(redirectUriAfterLogin)) {
+			redirectUriAfterLogin = URLEncoder.encode(redirectUriAfterLogin, UTF_8);
 			CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin,
 				COOKIE_EXPIRE_SECONDS);
 		}

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
@@ -165,7 +165,7 @@ class ProposalControllerTest extends ControllerTest {
 
 	}
 
-	@Test
+	@Test // 신청서가 거절 됐는데 왜 저장이 되는건가요?
 	@DisplayName("[성공] 방장이 신청서를 거절하는 경우 신청서의 상태값이 'REFUSE' 로 변경되며 밥모임원에 저장된다.")
 	void update_proposalStatus_refuse_success() throws Exception {
 
@@ -177,7 +177,7 @@ class ProposalControllerTest extends ControllerTest {
 				.contentType(APPLICATION_JSON)
 				.header(AUTHORIZATION, BEARER_TYPE + accessToken1)
 				.content(jsonRequest))
-			.andExpect(status().isOk())
+			.andExpect(status().isNoContent())
 			.andDo(document("proposal-Refuse",
 				resource(
 					builder()


### PR DESCRIPTION
## 🌱 작업 사항 
#### 에러에 대해 설명 드리면 두 가지 포인트에서 문제가 발생했습니다.
### 1. 쿠키에 한글이 저장 될 수 없다.
  - OAuth 요청시에 redirect_uri를 저장하기 위해 쿠키를 사용하고 있습니다.(HttpCookieOAuthAuthorizationRequestRepository)  
  - 프론트에서 redirect_uri에 쿼리를 함께 보내고 있습니다. 
  - 쿼리 중에서 "name" (가게 이름) 에 한글이 들어갑니다.
  - 따라서, 한글로 이루어진 uri를 쿠키에 저장할 수가 없어서 에러가 발생하게 됩니다.
  - 해당 문제는 쿠키에 저장하기 전에 인코딩 과정을 추가하고 다시 쿠키에서 가져올 때 디코딩 과정을 추가함으로서 해결하였습니다.
- 참고: [쿠키(Cookie)에 한글 데이터 저장하고 가져오기](https://dololak.tistory.com/537)

### 2. Redirect시에도 한글로 된 문자를 URI에 포함할 수 없다.
 - 위와 비슷한 맥락입니다.
 - 쿠키에서 꺼내온 redirect_uri에 쿼리 파라미터로 한글이 들어가 있기 때문에 정상적으로 Redirect가 안되었습니다.
 - 해당 문제는 **`"name="`** 을 기준으로 Split 한후에 파라미터에 해당하는 부분(가게 이름)만 따로 한번 더 인코딩한 후에 프론트에 전달하여 해결했습니다.
- 참고: [Redirect 시 한글 파라미터가 깨지는 문제](https://ivvve.github.io/2019/01/20/java/Spring/redirect_URL_encoding/)

## ❓ 리뷰 포인트
- 일단 현재 문제가 되는 쿼리는 `name` 뿐이라서 하드 코딩으로 구현 했는데 좀 더 범용성 있는 방식을 사용하고자 하는데 좋은 아이디어나 알고리즘이 있다면 제안 부탁드립니다~!

## 🦄 관련 이슈
- resolves #186



