### PR TITLE
[#179] User 매너 온도 BigDecimal 타입으로 변경하여 소수점 에러 해결

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/dto/response/UserProfileResponse.java
@@ -8,6 +8,6 @@ public record UserProfileResponse(
 	Integer leaderCount,
 	Integer crewCount,
 	Integer tasteScore,
-	Double mannerScore
+	String mannerScore
 ) {
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
@@ -3,6 +3,7 @@ package com.prgrms.mukvengers.domain.user.model;
 import static javax.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
+import java.math.BigDecimal;
 import java.util.Objects;
 
 import javax.persistence.Column;
@@ -31,8 +32,8 @@ import lombok.NoArgsConstructor;
 public class User extends BaseEntity {
 
 	public static final String DEFAULT_INTRODUCE = "자기소개를 작성해주세요";
-	public static final Double DEFAULT_MANNER_VALUE = 36.5;
 	public static final Integer ZERO = 0;
+	public static final BigDecimal CRITERIA = new BigDecimal("0.1");
 
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
@@ -54,7 +55,7 @@ public class User extends BaseEntity {
 	private String oauthId;
 
 	@Column(nullable = false)
-	private Double mannerScore;
+	private BigDecimal mannerScore;
 
 	@Column(nullable = false)
 	private Integer tasteScore;
@@ -78,7 +79,7 @@ public class User extends BaseEntity {
 		this.provider = provider;
 		this.oauthId = oauthId;
 		this.introduction = DEFAULT_INTRODUCE;
-		this.mannerScore = DEFAULT_MANNER_VALUE;
+		this.mannerScore = new BigDecimal("36.5");
 		this.tasteScore = ZERO;
 		this.leaderCount = ZERO;
 		this.crewCount = ZERO;
@@ -115,7 +116,9 @@ public class User extends BaseEntity {
 	}
 
 	public void addMannerScore(Integer mannerScore) {
-		this.mannerScore += (0.1 * mannerScore);
+		BigDecimal score = CRITERIA.multiply(new BigDecimal(mannerScore));
+		BigDecimal result = this.mannerScore.add(score);
+		this.mannerScore = checkMinusMannerScore(result);
 	}
 
 	public void addTasteScore(Integer tasteScore) {
@@ -130,4 +133,14 @@ public class User extends BaseEntity {
 		this.crewCount++;
 	}
 
+	public BigDecimal checkMinusMannerScore(BigDecimal mannerScore) {
+
+		BigDecimal zero = new BigDecimal("0.0");
+
+		// 값 비교를 위해 사용하며 값이 동일하면 0, 적으면 -1, 많으면 1을 반환함
+		if (mannerScore.compareTo(zero) > 0) {
+			return mannerScore;
+		}
+		return zero;
+	}
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
@@ -2,6 +2,7 @@ package com.prgrms.mukvengers.domain.user.model;
 
 import static javax.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
+import static org.springframework.util.Assert.*;
 
 import java.math.BigDecimal;
 import java.util.Objects;
@@ -116,6 +117,7 @@ public class User extends BaseEntity {
 	}
 
 	public void addMannerScore(Integer mannerScore) {
+		notNull(mannerScore, "유효하지 않는 매너 온도입니다.");
 		BigDecimal score = CRITERIA.multiply(new BigDecimal(mannerScore));
 		BigDecimal result = this.mannerScore.add(score);
 		this.mannerScore = checkMinusMannerScore(result);

--- a/src/main/resources/db/migration/V4__alter_user_table.sql
+++ b/src/main/resources/db/migration/V4__alter_user_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    MODIFY manner_score DECIMAL(3, 1) NOT NULL DEFAULT 36.5;

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
@@ -117,8 +117,7 @@ class ProposalControllerTest extends ControllerTest {
 							fieldWithPath("data.user.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.user.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.user.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.user.mannerScore").type(NUMBER).description("매너 온도"),
-							fieldWithPath("data.user.mannerScore").type(NUMBER).description("매너 온도"))
+							fieldWithPath("data.user.mannerScore").type(STRING).description("매너 온도"))
 						.build()
 				)
 			));
@@ -150,7 +149,7 @@ class ProposalControllerTest extends ControllerTest {
 							fieldWithPath("data.responses.[].user.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.responses.[].user.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.responses.[].user.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.responses.[].user.mannerScore").type(NUMBER).description("매너 온도"),
+							fieldWithPath("data.responses.[].user.mannerScore").type(STRING).description("매너 온도"),
 							fieldWithPath("data.responses.[].id").type(NUMBER).description("신청서 아이디"),
 							fieldWithPath("data.responses.[].content").type(STRING).description("신청서 내용"),
 							fieldWithPath("data.responses.[].status").type(STRING).description("신청서 상태"),
@@ -220,8 +219,7 @@ class ProposalControllerTest extends ControllerTest {
 							fieldWithPath("data.responses.[].user.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.responses.[].user.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.responses.[].user.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.responses.[].user.mannerScore").type(NUMBER).description("매너 온도"),
-							fieldWithPath("data.responses.[].user.mannerScore").type(NUMBER).description("매너 온도"),
+							fieldWithPath("data.responses.[].user.mannerScore").type(STRING).description("매너 온도"),
 							fieldWithPath("data.responses.[].id").type(NUMBER).description("신청서 아이디"),
 							fieldWithPath("data.responses.[].content").type(STRING).description("신청서 내용"),
 							fieldWithPath("data.responses.[].status").type(STRING).description("신청서 상태"),

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
@@ -263,7 +263,7 @@ class ProposalServiceImplTest extends ServiceTest {
 			.hasFieldOrPropertyWithValue("leaderCount", user.getLeaderCount())
 			.hasFieldOrPropertyWithValue("crewCount", user.getCrewCount())
 			.hasFieldOrPropertyWithValue("tasteScore", user.getTasteScore())
-			.hasFieldOrPropertyWithValue("mannerScore", user.getMannerScore());
+			.hasFieldOrPropertyWithValue("mannerScore", String.valueOf(user.getMannerScore()));
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
@@ -173,7 +173,7 @@ class ReviewControllerTest extends ControllerTest {
 							fieldWithPath("data.reviewee.leaderCount").type(NUMBER).description("리뷰이의 리더 횟수"),
 							fieldWithPath("data.reviewee.crewCount").type(NUMBER).description("리뷰이의 밥모임 참여한 횟수"),
 							fieldWithPath("data.reviewee.tasteScore").type(NUMBER).description("리뷰이의 맛잘알 점수"),
-							fieldWithPath("data.reviewee.mannerScore").type(NUMBER).description("리뷰이의 매너 점수"),
+							fieldWithPath("data.reviewee.mannerScore").type(STRING).description("리뷰이의 매너 점수"),
 
 							fieldWithPath("data.crew.currentMember").type(NULL).description("밥모임의 아이디"),
 							fieldWithPath("data.crew.id").type(NUMBER).description("밥모임의 아이디"),
@@ -239,7 +239,7 @@ class ReviewControllerTest extends ControllerTest {
 								.description("리뷰를 작성하고자 하는 사용자의 밥모임 참여 횟수"),
 							fieldWithPath("data.content.[].reviewer.tasteScore").type(NUMBER)
 								.description("리뷰를 작성하고자 하는 사용자의 맛잘알 점수"),
-							fieldWithPath("data.content.[].reviewer.mannerScore").type(NUMBER)
+							fieldWithPath("data.content.[].reviewer.mannerScore").type(STRING)
 								.description("리뷰를 작성하고자 하는 사용자의 매너 온도 점수"),
 
 							fieldWithPath("data.content.[].reviewee.id").type(NUMBER).description("리뷰 남기고자하는 사용자의 아이디"),
@@ -255,7 +255,7 @@ class ReviewControllerTest extends ControllerTest {
 								.description("리뷰 남기고자하는 사용자의 밥모임 참여 횟수"),
 							fieldWithPath("data.content.[].reviewee.tasteScore").type(NUMBER)
 								.description("리뷰 남기고자하는 사용자의 맛잘알 점수"),
-							fieldWithPath("data.content.[].reviewee.mannerScore").type(NUMBER)
+							fieldWithPath("data.content.[].reviewee.mannerScore").type(STRING)
 								.description("리뷰 남기고자하는 사용자의 매너 온도 점수"),
 
 							fieldWithPath("data.content.[].crew.id").type(NUMBER).description("리뷰하고자하는 밥 모임 아이디"),
@@ -346,7 +346,7 @@ class ReviewControllerTest extends ControllerTest {
 								.description("리뷰를 작성하고자 하는 사용자의 밥모임 참여 횟수"),
 							fieldWithPath("data.content.[].reviewer.tasteScore").type(NUMBER)
 								.description("리뷰를 작성하고자 하는 사용자의 맛잘알 점수"),
-							fieldWithPath("data.content.[].reviewer.mannerScore").type(NUMBER)
+							fieldWithPath("data.content.[].reviewer.mannerScore").type(STRING)
 								.description("리뷰를 작성하고자 하는 사용자의 매너 온도 점수"),
 
 							fieldWithPath("data.content.[].reviewee.id").type(NUMBER).description("리뷰 남기고자하는 사용자의 아이디"),
@@ -362,7 +362,7 @@ class ReviewControllerTest extends ControllerTest {
 								.description("리뷰 남기고자하는 사용자의 밥모임 참여 횟수"),
 							fieldWithPath("data.content.[].reviewee.tasteScore").type(NUMBER)
 								.description("리뷰 남기고자하는 사용자의 맛잘알 점수"),
-							fieldWithPath("data.content.[].reviewee.mannerScore").type(NUMBER)
+							fieldWithPath("data.content.[].reviewee.mannerScore").type(STRING)
 								.description("리뷰 남기고자하는 사용자의 매너 온도 점수"),
 
 							fieldWithPath("data.content.[].crew.id").type(NUMBER).description("리뷰하고자하는 밥 모임 아이디"),

--- a/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
@@ -4,7 +4,9 @@ import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.ReviewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,8 +65,13 @@ class ReviewServiceImplTest extends ServiceTest {
 		Optional<Review> findReview = reviewRepository.findById(leaderReview.id());
 
 		// then
-		assertThat(findReview).isPresent();
-		assertThat(findReview.get().getReviewee().getId()).isEqualTo(leader.getUserId());
+		assertThat(findReview)
+			.hasValueSatisfying(review -> assertAll(
+				() -> assertThat(review.getReviewee().getId()).isEqualTo(leader.getUserId()),
+				() -> assertThat(review.getMannerScore()).isEqualTo(MANNER_SCORE),
+				() -> assertThat(review.getTasteScore()).isEqualTo(TASTE_SCORE),
+				() -> assertThat(review.getReviewee().getMannerScore()).isEqualTo(new BigDecimal("37.0"))
+			));
 	}
 
 	@Test
@@ -85,13 +92,16 @@ class ReviewServiceImplTest extends ServiceTest {
 		CreateMemberReviewRequest memberReviewRequest = createMemberReviewRequest(reviewee.getId());
 
 		// when
-		IdResponse review = reviewService.createMemberReview(memberReviewRequest, reviewer.getId(), crew.getId());
-		Optional<Review> findReview = reviewRepository.findById(review.id());
+		IdResponse memberReview = reviewService.createMemberReview(memberReviewRequest, reviewer.getId(), crew.getId());
+		Optional<Review> findReview = reviewRepository.findById(memberReview.id());
 
 		// then
-		assertThat(findReview).isPresent();
-		assertThat(findReview.get().getMannerScore()).isEqualTo(MANNER_SCORE);
-		assertThat(findReview.get().getTasteScore()).isZero();
+		assertThat(findReview)
+			.hasValueSatisfying(review -> assertAll(
+				() -> assertThat(review.getMannerScore()).isEqualTo(MANNER_SCORE),
+				() -> assertThat(review.getTasteScore()).isZero(),
+				() -> assertThat(review.getReviewee().getMannerScore()).isEqualTo(new BigDecimal("37.0"))
+			));
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
@@ -55,7 +55,7 @@ class UserControllerTest extends ControllerTest {
 							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도"))
+							fieldWithPath("data.mannerScore").type(STRING).description("매너 온도"))
 						.build()
 				))
 			);
@@ -93,7 +93,7 @@ class UserControllerTest extends ControllerTest {
 							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도"))
+							fieldWithPath("data.mannerScore").type(STRING).description("매너 온도"))
 						.build()
 				))
 			);
@@ -134,7 +134,7 @@ class UserControllerTest extends ControllerTest {
 							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
 							fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
 							fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
-							fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도"))
+							fieldWithPath("data.mannerScore").type(STRING).description("매너 온도"))
 						.build()
 				))
 			);

--- a/src/test/java/com/prgrms/mukvengers/domain/user/model/UserTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/model/UserTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.mukvengers.domain.user.model;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 import java.util.stream.Stream;
@@ -114,5 +115,22 @@ class UserTest {
 
 		// then
 		assertThat(user.getMannerScore()).isEqualTo(new BigDecimal("0.0"));
+	}
+
+	@Test
+	@DisplayName("[실패] mannerScore에 null 값이 들어온다면 매너 온도 연산처리할 수 없다.")
+	void mannerScore_null_fail() {
+
+		//given
+		User user = User.builder()
+			.nickname("테스트")
+			.profileImgUrl("https://defaultImg.jpg")
+			.provider("kakao")
+			.oauthId("12345")
+			.build();
+
+
+		// when & then
+		assertThrows(IllegalArgumentException.class, () -> user.addMannerScore(null));
 	}
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/user/model/UserTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/model/UserTest.java
@@ -2,6 +2,7 @@ package com.prgrms.mukvengers.domain.user.model;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.math.BigDecimal;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
@@ -41,7 +42,7 @@ class UserTest {
 			.hasFieldOrPropertyWithValue("leaderCount", 0)
 			.hasFieldOrPropertyWithValue("crewCount", 0)
 			.hasFieldOrPropertyWithValue("tasteScore", 0)
-			.hasFieldOrPropertyWithValue("mannerScore", 36.5)
+			.hasFieldOrPropertyWithValue("mannerScore", new BigDecimal("36.5"))
 			.hasFieldOrPropertyWithValue("provider", "kakao")
 			.hasFieldOrPropertyWithValue("oauthId", "12345")
 			.hasFieldOrPropertyWithValue("reportedCount", 0)
@@ -58,4 +59,60 @@ class UserTest {
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 
+	@Test
+	@DisplayName("[성공] mannerScore 를 양수값으로 받으면 mannerScore 값이 증가한다.")
+	void addMannerScore_add_success() {
+
+		//given
+		User user = User.builder()
+			.nickname("테스트")
+			.profileImgUrl("https://defaultImg.jpg")
+			.provider("kakao")
+			.oauthId("12345")
+			.build();
+
+		// when
+		user.addMannerScore(5);
+
+		// then
+		assertThat(user.getMannerScore()).isEqualTo(new BigDecimal("37.0"));
+	}
+
+	@Test
+	@DisplayName("[성공] mannerScore 를 음수값으로 받으면 mannerScore 값이 감소한다.")
+	void addMannerScore_minus_success() {
+
+		//given
+		User user = User.builder()
+			.nickname("테스트")
+			.profileImgUrl("https://defaultImg.jpg")
+			.provider("kakao")
+			.oauthId("12345")
+			.build();
+
+		// when
+		user.addMannerScore(-3);
+
+		// then
+		assertThat(user.getMannerScore()).isEqualTo(new BigDecimal("36.2"));
+	}
+
+	@Test
+	@DisplayName("[성공] mannerScore 값은 0.0 이하로 내려갈 수 없다.")
+	void mannerScore_notMinus_success() {
+
+		//given
+		User user = User.builder()
+			.nickname("테스트")
+			.profileImgUrl("https://defaultImg.jpg")
+			.provider("kakao")
+			.oauthId("12345")
+			.build();
+
+		// when
+		user.addMannerScore(-400);
+
+		// then
+		assertThat(user.getMannerScore()).isEqualTo(new BigDecimal("0.0"));
+	}
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/service/UserServiceTest.java
@@ -60,7 +60,7 @@ class UserServiceTest extends ServiceTest {
 				.hasFieldOrPropertyWithValue("leaderCount", 0)
 				.hasFieldOrPropertyWithValue("crewCount", 0)
 				.hasFieldOrPropertyWithValue("tasteScore", 0)
-				.hasFieldOrPropertyWithValue("mannerScore", 36.5)
+				.hasFieldOrPropertyWithValue("mannerScore", "36.5")
 			;
 		}
 

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -15,21 +15,21 @@ DROP TABLE IF EXISTS users;
 
 CREATE TABLE users
 (
-    id              bigint       NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    nickname        varchar(20)  NOT NULL,
-    introduction    varchar(100) NOT NULL,
-    profile_img_url varchar(255) NOT NULL,
-    taste_score     bigint       NOT NULL DEFAULT 0,
-    manner_score    double       NOT NULL DEFAULT 36.5,
-    leader_count    int          NOT NULL DEFAULT 0,
-    crew_count      int          NOT NULL DEFAULT 0,
-    reported_count  int          NOT NULL DEFAULT 0,
-    enabled         boolean      NOT NULL DEFAULT false,
-    provider        varchar(10)  NOT NULL,
-    oauth_id        varchar(255) NOT NULL,
-    created_at      dateTime     NOT NULL DEFAULT now(),
-    updated_at      dateTime     NOT NULL DEFAULT now(),
-    deleted         boolean      NOT NULL DEFAULT false
+    id              bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    nickname        varchar(20)   NOT NULL,
+    introduction    varchar(100)  NOT NULL,
+    profile_img_url varchar(255)  NOT NULL,
+    taste_score     bigint        NOT NULL DEFAULT 0,
+    manner_score    decimal(3, 1) NOT NULL DEFAULT 36.5,
+    leader_count    int           NOT NULL DEFAULT 0,
+    crew_count      int           NOT NULL DEFAULT 0,
+    reported_count  int           NOT NULL DEFAULT 0,
+    enabled         boolean       NOT NULL DEFAULT false,
+    provider        varchar(10)   NOT NULL,
+    oauth_id        varchar(255)  NOT NULL,
+    created_at      dateTime      NOT NULL DEFAULT now(),
+    updated_at      dateTime      NOT NULL DEFAULT now(),
+    deleted         boolean       NOT NULL DEFAULT false
 );
 
 CREATE TABLE store
@@ -46,7 +46,7 @@ CREATE TABLE store
     created_at        dateTime     NOT NULL DEFAULT now(),
     updated_at        dateTime     NOT NULL DEFAULT now(),
     deleted           boolean      NOT NULL DEFAULT false,
-    
+
     UNIQUE KEY uk_store_place_id (place_id)
 );
 


### PR DESCRIPTION
브랜치를 잘못 관리해서 새로운 PR 날립니다. 죄송합니다🫠

### 🌱 작업 사항 
- UserProfileResponse 클래스의 매너 온도(mannerScore) 타입을 `Double`에서 `String`값로 변경
  - API 응답 시 혹시 모를 **소수점 이하에서의 데이터 유실을 확실하게 예방하기 위해 문자열**로 응답하였습니다.
  - 그와 관련된 Controller 테스트에서의 mannerScore 타입을 type(NUMBER) 에서 type(STRING) 으로 변경하였습니다.
- User 클래스의 매너 온도(mannerScore)의 타입을 `Double`에서 `BigDecimal`로 변경
  - float과 double 타입은 부동 소수점으로 **정확한 값이 아닌 근사치**를 나타내서 데이터 **정확도 문제**가 발생할 수 있습니다.
  - 이로인해 사칙 연산 시 **기대한 값과 다른 값을 출력하는 경우가 생길 수 있어** Double에서 BigDecimal로 변경하였습니다.
  - 물론, mannerScore의 소수 2번째 자리를 반올림하여 mannerScore를 소수 1번째 자리까지 저장하면 해결할 수 있지만,
  사칙 연산 처리하여 해결하기 보다는 BigDecimal를 사용하여 보다 더 정확한 값을 관리하고 싶어 사용하였습니다!
  - [BigDecimal 참고 자료](https://jsonobject.tistory.com/466)
- User 클래스의 addMannerScore 메소드에서 **매너 온도가 음수값이 되지 않도록 checkMinusMannerScore** 메소드를 통해 유효성 검증
  - User 클래스의 **기존 addMannerScore** 메소드

  ```java
  public void addMannerScore(Integer mannerScore) {
      this.mannerScore += (0.1 * mannerScore);
  }
  ``` 
  - User 클래스의 **변경된 addMannerScore** 메소드
 
  ```java
  public void addMannerScore(Integer mannerScore) {
      BigDecimal score = CRITERIA.multiply(new BigDecimal(mannerScore));
      BigDecimal result = this.mannerScore.add(score);
      this.mannerScore = checkMinusMannerScore(result);
  }
  ``` 
  - 매너 온도가 **음수 값이 되지 않도록 검증하는 checkMinusMannerScore** 메소드

  ```java
  public BigDecimal checkMinusMannerScore(BigDecimal mannerScore) {

    BigDecimal zero = new BigDecimal("0.0");

    // 값 비교를 위해 사용하며 값이 동일하면 0, 적으면 -1, 많으면 1을 반환함
    if (mannerScore.compareTo(zero) > 0) {
      return mannerScore;
    }
    return zero;
  }
  ``` 

- User 테이블의 mannerScore 타입 `double` 에서 `Decimal` 타입으로 변경
  - Decimal(n, m)에서 n은 길이를 m은 소수점 자리를 의미합니다.
    - (예) manner_score DECIMAL(3, 1) 은 길이가 3이고 소수점 자리는 1인 것을 말함
-  UserTest 에서 mannerScore 값 검증합니다.
- ReviewServiceTest에서 addMannerScore 메소드 검증
  - addMannerScore 메소드에서 mannerScore에 올바른 값이 저장되는지 확인합니다.


### ❓ 리뷰 포인트
- checkMinusMannerScore 메소드를 제네릭을 이용하여 재사용할 수 있도록 ValidateUtil 클래스에 작성하고 싶었습니다. 하지만, 파라미터에 제네릭 타입 사용 시 조건식에 compareTo 메소드를 사용할 수 없어 우선 User 클래스에 작성하였습니다. 어떻게 해결할 수 있을까요? 아니면 checkMinusMannerScore 메소드가 User클래스에 있는 것에 대해서 어떻게 생각하시나요?
### 🦄 관련 이슈
resolves #179 



