### PR TITLE
This merge history has been canceled.

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/notification/api/NotificationController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/api/NotificationController.java
@@ -47,8 +47,9 @@ public class NotificationController {
 	 * 알림 상태를 읽음으로 변경
 	 */
 	@PatchMapping(value = "/notifications/{id}")
-	public ResponseEntity<Void> readNotification(@PathVariable Long id) {
-		notificationService.readNotification(id);
+	public ResponseEntity<Void> readNotification(@AuthenticationPrincipal JwtAuthentication user,
+		@PathVariable Long id) {
+		notificationService.readNotification(user.id(), id);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/api/NotificationController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/api/NotificationController.java
@@ -1,0 +1,54 @@
+package com.prgrms.mukvengers.domain.notification.api;
+
+import static org.springframework.http.MediaType.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponses;
+import com.prgrms.mukvengers.domain.notification.service.NotificationService;
+import com.prgrms.mukvengers.global.security.token.dto.jwt.JwtAuthentication;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	/**
+	 * 로그인 한 유저 sse 연결
+	 */
+	@GetMapping(value = "/subscribe", produces = TEXT_EVENT_STREAM_VALUE)
+	@ResponseStatus(HttpStatus.OK)
+	public SseEmitter subscribe(@AuthenticationPrincipal JwtAuthentication user,
+		@RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+		return notificationService.subscribe(user.id(), lastEventId);
+	}
+
+	/**
+	 * 로그인 한 유저의 모든 알림 조회
+	 */
+	@GetMapping(value = "/notifications", produces = APPLICATION_JSON_VALUE)
+	public ResponseEntity<NotificationResponses> notifications(@AuthenticationPrincipal JwtAuthentication user) {
+		return ResponseEntity.ok().body(notificationService.findAllById(user.id()));
+	}
+
+	/**
+	 * 알림 상태를 읽음으로 변경
+	 */
+	@PatchMapping(value = "/notifications/{id}")
+	public ResponseEntity<Void> readNotification(@PathVariable Long id) {
+		notificationService.readNotification(id);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,12 @@
+package com.prgrms.mukvengers.domain.notification.dto.response;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+	Long id,
+	String type,
+	String content,
+	LocalDateTime createdAt,
+	boolean isRead
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/dto/response/NotificationResponses.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/dto/response/NotificationResponses.java
@@ -1,0 +1,14 @@
+package com.prgrms.mukvengers.domain.notification.dto.response;
+
+import java.util.List;
+
+public record NotificationResponses(
+	List<NotificationResponse> notifications,
+	long unReadCount
+) {
+
+	public NotificationResponses(List<NotificationResponse> notifications, long unReadCount) {
+		this.notifications = notifications;
+		this.unReadCount = unReadCount;
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/exception/InvalidNotificationAccessException.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/exception/InvalidNotificationAccessException.java
@@ -1,0 +1,17 @@
+package com.prgrms.mukvengers.domain.notification.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+import com.prgrms.mukvengers.global.exception.ServiceException;
+
+public class InvalidNotificationAccessException extends ServiceException {
+	private static ErrorCode errorCode = ErrorCode.INVALID_NOTIFICATION_ACCESS;
+	private static String messageKey = "exception.notification.access.invalid";
+
+	public InvalidNotificationAccessException(Long notificationId) {
+		super(errorCode, messageKey, new Object[] {notificationId});
+	}
+
+	public InvalidNotificationAccessException(Long userId, Long notificationId) {
+		super(errorCode, messageKey, new Object[] {userId, notificationId});
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/exception/NotificationNotFoundException.java
@@ -6,7 +6,7 @@ import com.prgrms.mukvengers.global.exception.ServiceException;
 public class NotificationNotFoundException extends ServiceException {
 
 	private static final ErrorCode ERROR_CODE = ErrorCode.NOTIFICATION_NOT_FOUND;
-	private static final String MESSAGE_KEY = "exception.crew.notfound";
+	private static final String MESSAGE_KEY = "exception.notification.notExists";
 
 	public NotificationNotFoundException(Long notificationId) {
 		super(ERROR_CODE, MESSAGE_KEY, new Object[] {notificationId});

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,14 @@
+package com.prgrms.mukvengers.domain.notification.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+import com.prgrms.mukvengers.global.exception.ServiceException;
+
+public class NotificationNotFoundException extends ServiceException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.NOTIFICATION_NOT_FOUND;
+	private static final String MESSAGE_KEY = "exception.crew.notfound";
+
+	public NotificationNotFoundException(Long notificationId) {
+		super(ERROR_CODE, MESSAGE_KEY, new Object[] {notificationId});
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/mapper/NotificationMapper.java
@@ -1,0 +1,20 @@
+package com.prgrms.mukvengers.domain.notification.mapper;
+
+import static org.mapstruct.ReportingPolicy.*;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponse;
+import com.prgrms.mukvengers.domain.notification.model.Notification;
+
+@Mapper(componentModel = "spring", unmappedSourcePolicy = IGNORE)
+public interface NotificationMapper {
+
+	@Mapping(target = "content", source = "content.content")
+	@Mapping(target = "type", source = "type")
+	@Mapping(target = "id", source = "id")
+	@Mapping(target = "isRead", source = "isRead")
+	@Mapping(target = "createdAt", source = "createdAt")
+	NotificationResponse toNotificationResponse(Notification notification);
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/repository/EmitterRepository.java
@@ -1,0 +1,21 @@
+package com.prgrms.mukvengers.domain.notification.repository;
+
+import java.util.Map;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface EmitterRepository {
+	SseEmitter save(String id, SseEmitter sseEmitter);
+
+	void saveEventCache(String eventCacheId, Object event);
+
+	Map<String, SseEmitter> findAllStartWithById(String userId);
+
+	Map<String, Object> findAllEventCacheStartWithId(String userId);
+
+	void deleteAllStartWithId(String userId);
+
+	void deleteById(String id);
+
+	void deleteAllEventCacheStartWithId(String userId);
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/repository/MemoryEmitterRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/repository/MemoryEmitterRepository.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class MemoryEmitterRepository implements EmitterRepository {
 	public final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 	private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+	private String delimiter;
 
 	@Override
 	public SseEmitter save(String id, SseEmitter sseEmitter) {
@@ -25,23 +26,29 @@ public class MemoryEmitterRepository implements EmitterRepository {
 
 	@Override
 	public Map<String, SseEmitter> findAllStartWithById(String userId) {
+		delimiter = userId + "_";
+
 		return emitters.entrySet().stream()
-			.filter(entry -> entry.getKey().startsWith(userId))
+			.filter(entry -> entry.getKey().startsWith(delimiter))
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	@Override
 	public Map<String, Object> findAllEventCacheStartWithId(String userId) {
+		delimiter = userId + "_";
+
 		return eventCache.entrySet().stream()
-			.filter(entry -> entry.getKey().startsWith(userId))
+			.filter(entry -> entry.getKey().startsWith(delimiter))
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	@Override
 	public void deleteAllStartWithId(String userId) {
+		delimiter = userId + "_";
+
 		emitters.forEach(
 			(key, emitter) -> {
-				if (key.startsWith(userId)) {
+				if (key.startsWith(delimiter)) {
 					emitters.remove(key);
 				}
 			}
@@ -55,9 +62,11 @@ public class MemoryEmitterRepository implements EmitterRepository {
 
 	@Override
 	public void deleteAllEventCacheStartWithId(String userId) {
+		delimiter = userId + "_";
+
 		eventCache.forEach(
 			(key, data) -> {
-				if (key.startsWith(userId)) {
+				if (key.startsWith(delimiter)) {
 					eventCache.remove(key);
 				}
 			}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/repository/MemoryEmitterRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/repository/MemoryEmitterRepository.java
@@ -13,17 +13,27 @@ public class MemoryEmitterRepository implements EmitterRepository {
 	private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
 	private String delimiter;
 
+	/**
+	 * 알림 발송 전 Notification 객체를 emitters에 저장하게 됩니다.
+	 * [key = userId_현재시간, value = 연결 요청 시 생성한 Emitter 객체]
+	 */
 	@Override
 	public SseEmitter save(String id, SseEmitter sseEmitter) {
 		emitters.put(id, sseEmitter);
 		return sseEmitter;
 	}
 
+	/**
+	 * 알림 발송 후 Notification 객체를 EventCache에 저장하게 됩니다.
+	 */
 	@Override
 	public void saveEventCache(String eventCacheId, Object event) {
 		eventCache.put(eventCacheId, event);
 	}
 
+	/**
+	 * 유저 ID를 이용해 특정 유저의 SseEmitter를 조회합니다.
+	 */
 	@Override
 	public Map<String, SseEmitter> findAllStartWithById(String userId) {
 		delimiter = userId + "_";
@@ -33,6 +43,9 @@ public class MemoryEmitterRepository implements EmitterRepository {
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
+	/**
+	 * 유저 ID를 이용해 EventCache에서 특정 유저에게 전송되었던 알림들을 조회합니다.
+	 */
 	@Override
 	public Map<String, Object> findAllEventCacheStartWithId(String userId) {
 		delimiter = userId + "_";
@@ -42,6 +55,10 @@ public class MemoryEmitterRepository implements EmitterRepository {
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
+	/**
+	 * emitters에서 특정 유저의 Emitter를 일괄 삭제합니다.
+	 * Emitter의 timeout, OnCompletion이 호출될 경우 콜백으로 실행됩니다.
+	 */
 	@Override
 	public void deleteAllStartWithId(String userId) {
 		delimiter = userId + "_";
@@ -60,6 +77,9 @@ public class MemoryEmitterRepository implements EmitterRepository {
 		emitters.remove(id);
 	}
 
+	/**
+	 * evnetCache에서 특정 유저의 알람 목록을 삭제합니다.
+	 */
 	@Override
 	public void deleteAllEventCacheStartWithId(String userId) {
 		delimiter = userId + "_";

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/repository/MemoryEmitterRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/repository/MemoryEmitterRepository.java
@@ -1,0 +1,66 @@
+package com.prgrms.mukvengers.domain.notification.repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class MemoryEmitterRepository implements EmitterRepository {
+	public final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+	private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+	@Override
+	public SseEmitter save(String id, SseEmitter sseEmitter) {
+		emitters.put(id, sseEmitter);
+		return sseEmitter;
+	}
+
+	@Override
+	public void saveEventCache(String eventCacheId, Object event) {
+		eventCache.put(eventCacheId, event);
+	}
+
+	@Override
+	public Map<String, SseEmitter> findAllStartWithById(String userId) {
+		return emitters.entrySet().stream()
+			.filter(entry -> entry.getKey().startsWith(userId))
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
+
+	@Override
+	public Map<String, Object> findAllEventCacheStartWithId(String userId) {
+		return eventCache.entrySet().stream()
+			.filter(entry -> entry.getKey().startsWith(userId))
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
+
+	@Override
+	public void deleteAllStartWithId(String userId) {
+		emitters.forEach(
+			(key, emitter) -> {
+				if (key.startsWith(userId)) {
+					emitters.remove(key);
+				}
+			}
+		);
+	}
+
+	@Override
+	public void deleteById(String id) {
+		emitters.remove(id);
+	}
+
+	@Override
+	public void deleteAllEventCacheStartWithId(String userId) {
+		eventCache.forEach(
+			(key, data) -> {
+				if (key.startsWith(userId)) {
+					eventCache.remove(key);
+				}
+			}
+		);
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/repository/NotificationRepository.java
@@ -1,8 +1,12 @@
 package com.prgrms.mukvengers.domain.notification.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.prgrms.mukvengers.domain.notification.model.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	List<Notification> findAllByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/service/NotificationService.java
@@ -1,0 +1,128 @@
+package com.prgrms.mukvengers.domain.notification.service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponse;
+import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponses;
+import com.prgrms.mukvengers.domain.notification.exception.NotificationNotFoundException;
+import com.prgrms.mukvengers.domain.notification.mapper.NotificationMapper;
+import com.prgrms.mukvengers.domain.notification.model.Notification;
+import com.prgrms.mukvengers.domain.notification.model.vo.NotificationType;
+import com.prgrms.mukvengers.domain.notification.repository.EmitterRepository;
+import com.prgrms.mukvengers.domain.notification.repository.NotificationRepository;
+import com.prgrms.mukvengers.domain.notification.util.NotificationFactory;
+import com.prgrms.mukvengers.domain.user.exception.UserNotFoundException;
+import com.prgrms.mukvengers.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+	private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+
+	private final NotificationRepository notificationRepository;
+	private final EmitterRepository emitterRepository;
+	private final NotificationMapper notificationMapper;
+	private final NotificationFactory notificationFactory;
+	private final UserRepository userRepository;
+
+	//최초 구독 요청
+	public SseEmitter subscribe(Long userId, String lastEventId) {
+		String emitterId = userId + "_" + System.currentTimeMillis();
+		SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+
+		emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+		emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+
+		// 503 에러를 방지하기 위한 더미 이벤트 전송
+		sendNotification(emitter, emitterId, "EventStream Created. [userId=" + userId + "]");
+
+		// 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
+		if (!lastEventId.isEmpty()) {
+			Map<String, Object> events = emitterRepository.findAllEventCacheStartWithId(String.valueOf(userId));
+			events.entrySet().stream()
+				.filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+				.forEach(entry -> sendNotification(emitter, entry.getKey(), entry.getValue()));
+		}
+
+		return emitter;
+	}
+
+	private void sendNotification(SseEmitter emitter, String emitterId, Object data) {
+		try {
+			emitter.send(SseEmitter.event()
+				.id(emitterId)
+				.data(data));
+		} catch (IOException exception) {
+			emitterRepository.deleteById(emitterId);
+			log.error("SSE 연결 오류", exception);
+		}
+	}
+
+	public void send(Long receiverId, String content, NotificationType type) {
+		validateReceiver(receiverId);
+
+		Notification notification = save(receiverId, content, type);
+		String id = String.valueOf(receiverId);
+
+		Map<String, SseEmitter> emitters = emitterRepository.findAllStartWithById(id);
+
+		emitters.forEach(
+			(key, emitter) -> {
+				emitterRepository.saveEventCache(key, notification);
+				sendNotification(emitter, key, notificationMapper.toNotificationResponse(notification));
+			}
+		);
+	}
+
+	@Transactional
+	public Notification save(Long receiverId, String content, NotificationType type) {
+		validateReceiver(receiverId);
+
+		Notification notification = notificationFactory.createNotification(receiverId, content, type);
+		notificationRepository.save(notification);
+
+		return notification;
+	}
+
+	@Transactional
+	public NotificationResponses findAllById(Long userId) {
+		validateReceiver(userId);
+
+		List<NotificationResponse> responses = notificationRepository.findAllByReceiverId(userId)
+			.stream()
+			.map(notificationMapper::toNotificationResponse)
+			.toList();
+
+		long unreadCount = responses.stream()
+			.filter(notification -> !notification.isRead())
+			.count();
+
+		return new NotificationResponses(responses, unreadCount);
+	}
+
+	@Transactional
+	public void readNotification(Long notificationId) {
+		Notification notification = notificationRepository.findById(notificationId)
+			.orElseThrow(() -> new NotificationNotFoundException(notificationId));
+
+		notification.read();
+	}
+
+	private void validateReceiver(Long receiverId) {
+		if (!userRepository.existsById(receiverId)) {
+			throw new UserNotFoundException(receiverId);
+		}
+
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/service/NotificationService.java
@@ -3,6 +3,7 @@ package com.prgrms.mukvengers.domain.notification.service;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +11,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponse;
 import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponses;
+import com.prgrms.mukvengers.domain.notification.exception.InvalidNotificationAccessException;
 import com.prgrms.mukvengers.domain.notification.exception.NotificationNotFoundException;
 import com.prgrms.mukvengers.domain.notification.mapper.NotificationMapper;
 import com.prgrms.mukvengers.domain.notification.model.Notification;
@@ -141,9 +143,13 @@ public class NotificationService {
 	 알림을 읽음처리합니다.
 	 */
 	@Transactional
-	public void readNotification(Long notificationId) {
+	public void readNotification(Long userId, Long notificationId) {
 		Notification notification = notificationRepository.findById(notificationId)
 			.orElseThrow(() -> new NotificationNotFoundException(notificationId));
+
+		if (!Objects.equals(userId, notification.getReceiverId())) {
+			throw new InvalidNotificationAccessException(userId, notificationId);
+		}
 
 		notification.read();
 	}

--- a/src/main/java/com/prgrms/mukvengers/domain/notification/util/NotificationFactory.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/notification/util/NotificationFactory.java
@@ -1,0 +1,18 @@
+package com.prgrms.mukvengers.domain.notification.util;
+
+import org.springframework.stereotype.Component;
+
+import com.prgrms.mukvengers.domain.notification.model.Notification;
+import com.prgrms.mukvengers.domain.notification.model.vo.NotificationType;
+
+@Component
+public class NotificationFactory {
+	public Notification createNotification(Long receiverId, String content, NotificationType type) {
+		return Notification.builder()
+			.content(content)
+			.isRead(false)
+			.receiverId(receiverId)
+			.type(type)
+			.build();
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
@@ -59,7 +59,9 @@ public enum ErrorCode {
 	EXCEPTION_IN_WEBSOCKET(HttpStatus.UNAUTHORIZED, "W001", "웹 소켓 연결 중에 예외가 발생하였습니다."),
 
 	//SSE
-	INVALID_NOTIFICATION_CONTENT(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "올바르지 않은 알림 메시지입니다.");
+	INVALID_NOTIFICATION_CONTENT(HttpStatus.BAD_REQUEST, "N001", "올바르지 않은 알림 메시지입니다."),
+	EXCEPTION_IN_NOTIFICATION(HttpStatus.INTERNAL_SERVER_ERROR, "N002", "알림 전송에 실패했습니다."),
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "N003", "존재하지 않는 알림입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
@@ -60,8 +60,9 @@ public enum ErrorCode {
 
 	//SSE
 	INVALID_NOTIFICATION_CONTENT(HttpStatus.BAD_REQUEST, "N001", "올바르지 않은 알림 메시지입니다."),
-	EXCEPTION_IN_NOTIFICATION(HttpStatus.INTERNAL_SERVER_ERROR, "N002", "알림 전송에 실패했습니다."),
-	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "N003", "존재하지 않는 알림입니다.");
+	INVALID_NOTIFICATION_ACCESS(HttpStatus.BAD_REQUEST, "N002", "알림에 접근 권한이 없습니다."),
+	EXCEPTION_IN_NOTIFICATION(HttpStatus.INTERNAL_SERVER_ERROR, "N003", "알림 전송에 실패했습니다."),
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "N004", "존재하지 않는 알림입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/resources/db/migration/V4.2__alter_notification_table.sql
+++ b/src/main/resources/db/migration/V4.2__alter_notification_table.sql
@@ -1,10 +1,9 @@
 # 컬럼명 수정: isRead를 is_read로 변경
 ALTER TABLE notification
-    CHANGE isRead is_read boolean;
+    CHANGE isRead is_read Boolean;
 
 ALTER TABLE notification
     CHANGE receiver receiver_id bigint;
-
 
 # receiver_id 인덱스 추가
 create index idx_receiver_id on notification (receiver_id);

--- a/src/main/resources/db/migration/V4.2__alter_notification_table.sql
+++ b/src/main/resources/db/migration/V4.2__alter_notification_table.sql
@@ -1,0 +1,10 @@
+# 컬럼명 수정: isRead를 is_read로 변경
+ALTER TABLE notification
+    CHANGE isRead is_read boolean;
+
+ALTER TABLE notification
+    CHANGE receiver receiver_id boolean;
+
+
+# receiver_id 인덱스 추가
+create index idx_receiver_id on notification (receiver_id);

--- a/src/main/resources/db/migration/V4.2__alter_notification_table.sql
+++ b/src/main/resources/db/migration/V4.2__alter_notification_table.sql
@@ -3,7 +3,7 @@ ALTER TABLE notification
     CHANGE isRead is_read boolean;
 
 ALTER TABLE notification
-    CHANGE receiver receiver_id boolean;
+    CHANGE receiver receiver_id bigint;
 
 
 # receiver_id 인덱스 추가

--- a/src/main/resources/messages/exceptions/exception.properties
+++ b/src/main/resources/messages/exceptions/exception.properties
@@ -9,17 +9,6 @@ exception.user.introduce.overLength=유저 소개 글이 최대 글자 수를 �
 exception.user.nickName.overLength=유저 닉네임이 최대 글자 수를 초과하였습니다.
 exception.user.nickName.text=유저 닉네임이 공백이거나 비어있을 수 없습니다.
 
-## POST ##
-exception.post.notExists=존재하지 않는 포스트입니다.
-exception.post.content.overLength=게시글 내용의 최대 글자 수를 초과하였습나다.
-
-## COMMENT ##
-exception.comment.content.overLength=댓글 내용의 최대 글자 수를 초과하였습나다.
-exception.comment.content.empty=댓글 내용은 빈 값일 수 없습니다.
-exception.comment.notExists=존재하지 않는 댓글입니다.
-exception.comment.user.require=게시글은 작성자 정보가 필요합니다.
-exception.comment.text=댓글 내용은 공백이거나 비어있을 수 없습니다.
-
 ## VALIDATION ##
 javax.validation.constraints.AssertFalse.message={}는 false 이어야만 합니다.
 javax.validation.constraints.AssertTrue.message={}는 true 이어야만 합니다.
@@ -44,3 +33,5 @@ exception.jwtAuthenticationToken.isAuthenticated=인증 정보를 확인할 수 
 
 ## Notification ##
 exception.notification.content.invalid=올바르지 않은 알림 메시지입니다.
+exception.notification.notExists=존재하지 않는 알림입니다.
+exception.notification=알림 전송에 실패했습니다.

--- a/src/main/resources/messages/exceptions/exception.properties
+++ b/src/main/resources/messages/exceptions/exception.properties
@@ -33,5 +33,6 @@ exception.jwtAuthenticationToken.isAuthenticated=인증 정보를 확인할 수 
 
 ## Notification ##
 exception.notification.content.invalid=올바르지 않은 알림 메시지입니다.
+exception.notification.access.invalid=올바르지 않은 접근입니다.
 exception.notification.notExists=존재하지 않는 알림입니다.
 exception.notification=알림 전송에 실패했습니다.

--- a/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
@@ -46,6 +46,7 @@ public abstract class ControllerTest {
 	protected final String USER = "유저 API";
 	protected final String REVIEW = "리뷰 API";
 	protected final String PROPOSAL = "신청서 API";
+	protected final String NOTIFICATION = "알림 API";
 
 	protected final String BEARER_TYPE = "Bearer ";
 

--- a/src/test/java/com/prgrms/mukvengers/base/RepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/RepositoryTest.java
@@ -17,6 +17,7 @@ import com.prgrms.mukvengers.domain.chat.repository.ChatRepository;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
 import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
+import com.prgrms.mukvengers.domain.notification.repository.NotificationRepository;
 import com.prgrms.mukvengers.domain.proposal.repository.ProposalRepository;
 import com.prgrms.mukvengers.domain.review.repository.ReviewRepository;
 import com.prgrms.mukvengers.domain.store.model.Store;
@@ -50,6 +51,9 @@ public abstract class RepositoryTest {
 
 	@Autowired
 	protected ProposalRepository proposalRepository;
+
+	@Autowired
+	protected NotificationRepository notificationRepository;
 
 	protected User savedUser1;
 

--- a/src/test/java/com/prgrms/mukvengers/domain/notification/api/NotificationControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/notification/api/NotificationControllerTest.java
@@ -1,0 +1,95 @@
+package com.prgrms.mukvengers.domain.notification.api;
+
+import static com.prgrms.mukvengers.domain.notification.model.vo.NotificationType.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.prgrms.mukvengers.base.ControllerTest;
+import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponse;
+import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponses;
+import com.prgrms.mukvengers.domain.notification.service.NotificationService;
+
+class NotificationControllerTest extends ControllerTest {
+
+	@Autowired
+	private NotificationController notificationController;
+
+	@MockBean
+	private NotificationService notificationService;
+
+	@BeforeEach
+	public void setup() {
+		MockitoAnnotations.openMocks(this);
+	}
+
+	@Test
+	@DisplayName("[성공] SSE 연결을 진행한다.")
+	public void subscribe() throws Exception {
+		//given
+		given(notificationService.subscribe(anyLong(), anyString())).willReturn(new SseEmitter());
+
+		//when
+		ResultActions result = mockMvc.perform(get("/subscribe")
+			.header(AUTHORIZATION, BEARER_TYPE + accessToken1)
+			.accept(MediaType.TEXT_EVENT_STREAM)
+		);
+
+		//then
+		result.andExpect(status().isOk()).andDo(print());
+	}
+
+	@Test
+	@DisplayName("[성공] 로그인 한 사용자의 모든 알림 조회")
+	void findAllNotification() throws Exception {
+		// given
+		List<NotificationResponse> notificationList = Arrays.asList(
+			new NotificationResponse(10L, INFO.name(), "새로운 알림이 도착했습니다.", LocalDateTime.now().minusDays(1), false),
+			new NotificationResponse(12L, INFO.name(), "새로운 알림이 도착했습니다.", LocalDateTime.now().minusDays(3), false),
+			new NotificationResponse(14L, INFO.name(), "새로운 알림이 도착했습니다.", LocalDateTime.now().minusDays(5), false),
+			new NotificationResponse(16L, INFO.name(), "새로운 알림이 도착했습니다.", LocalDateTime.now().minusDays(7), false)
+		);
+		NotificationResponses notificationsResponse = new NotificationResponses(notificationList, 2L);
+		given(notificationService.findAllById(any())).willReturn(notificationsResponse);
+
+		// when
+		ResultActions result = mockMvc.perform(
+			get("/notifications")
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken1)
+				.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("[성공] 알림 조회 시 읽음 상태로 변경한다.")
+	void readNotification() throws Exception {
+		// given & when
+		ResultActions result = mockMvc.perform(
+			patch("/notifications/{id}", 1)
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken1)
+		);
+
+		// then
+		result.andExpect(status().isNoContent());
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/notification/model/NotificationTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/notification/model/NotificationTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.mukvengers.domain.notification.model;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -10,83 +11,93 @@ import org.junit.jupiter.params.provider.NullSource;
 import com.prgrms.mukvengers.domain.notification.exception.InvalidNotificationContentException;
 import com.prgrms.mukvengers.domain.notification.model.vo.NotificationContent;
 import com.prgrms.mukvengers.domain.notification.model.vo.NotificationType;
-import com.prgrms.mukvengers.domain.user.model.User;
-import com.prgrms.mukvengers.utils.UserObjectProvider;
 
 class NotificationTest {
 
 	@ParameterizedTest
 	@NullSource
 	@EmptySource
-	@DisplayName("알림 내용이 공백일 경우 커스텀 예외가 발생한다.")
+	@DisplayName("[실패] 알림 내용이 공백일 경우 커스텀 예외가 발생한다.")
 	public void createNotificationContent_fail(String content) {
 		//given
 
 		//when, then
-		Assertions.assertThrows(InvalidNotificationContentException.class, () -> new NotificationContent(content));
+		assertThrows(InvalidNotificationContentException.class, () -> new NotificationContent(content));
 	}
 
 	@Test
-	@DisplayName("알림 내용이 50글자 이상일 경우 커스텀 예외가 발생한다.")
+	@DisplayName("[실패] 알림 내용이 50글자 이상일 경우 커스텀 예외가 발생한다.")
 	public void createNotificationContent_fail2() {
 		//given
 
 		//when, then
-		Assertions.assertThrows(InvalidNotificationContentException.class,
+		assertThrows(InvalidNotificationContentException.class,
 			() -> new NotificationContent("hh".repeat(30)));
 	}
 
 	@Test
-	@DisplayName("알림 내용이 성공적으로 생성된다.")
+	@DisplayName("[성공] 알림 내용이 성공적으로 생성된다.")
 	public void createNotificationContent_success() {
 		//given
 
 		//when, then
-		Assertions.assertDoesNotThrow(() -> new NotificationContent("밥먹자"));
+		assertDoesNotThrow(() -> new NotificationContent("밥먹자"));
 	}
 
 	@Test
-	@DisplayName("Type 정보를 가진 알림이 성공적으로 생성된다.")
+	@DisplayName("[성공] Type 정보를 가진 알림이 성공적으로 생성된다.")
 	public void createNotification_success() {
 		//given
-		User user = UserObjectProvider.createUser();
 		String content = "신청서 도착했어용";
 		//when, then
 
-		Assertions.assertDoesNotThrow(() -> new Notification(content, false, user, NotificationType.CONNECT));
-		Assertions.assertDoesNotThrow(() -> new Notification(content, false, user, NotificationType.APPROVE));
-		Assertions.assertDoesNotThrow(() -> new Notification(content, false, user, NotificationType.REJECT));
+		assertDoesNotThrow(() -> new Notification(content, false, 1L, NotificationType.CONNECT));
+		assertDoesNotThrow(() -> new Notification(content, false, 1L, NotificationType.APPROVE));
+		assertDoesNotThrow(() -> new Notification(content, false, 1L, NotificationType.REJECT));
 	}
 
 	@ParameterizedTest
 	@NullSource
-	@DisplayName("Type 정보가 없는 경우 예외가 발생한다.")
+	@DisplayName("[실패] Type 정보가 없는 경우 예외가 발생한다.")
 	public void invalidType_fail(NotificationType type) {
 		//given
-		User user = UserObjectProvider.createUser();
 		String content = "신청서 도착했어용";
 		//when, then
 
-		Assertions.assertThrows(IllegalArgumentException.class,
-			() -> new Notification(content, false, user, type));
+		assertThrows(IllegalArgumentException.class,
+			() -> new Notification(content, false, 1L, type));
 	}
 
 	@ParameterizedTest
 	@NullSource
-	@DisplayName("receiver 정보가 없는 경우 예외가 발생한다.")
-	public void invalidReceiver_fail(User receiver) {
+	@DisplayName("[실패] receiver 정보가 없는 경우 예외가 발생한다.")
+	public void invalidReceiver_fail(Long receiverId) {
 		//given
 		String content = "신청서 도착했어용";
 
 		//when, then
-		Assertions.assertThrows(IllegalArgumentException.class,
-			() -> new Notification(content, false, receiver, NotificationType.CONNECT));
+		assertThrows(IllegalArgumentException.class,
+			() -> new Notification(content, false, receiverId, NotificationType.CONNECT));
 
-		Assertions.assertThrows(IllegalArgumentException.class,
-			() -> new Notification(content, false, receiver, NotificationType.APPROVE));
+		assertThrows(IllegalArgumentException.class,
+			() -> new Notification(content, false, receiverId, NotificationType.APPROVE));
 
-		Assertions.assertThrows(IllegalArgumentException.class,
-			() -> new Notification(content, false, receiver, NotificationType.REJECT));
+		assertThrows(IllegalArgumentException.class,
+			() -> new Notification(content, false, receiverId, NotificationType.REJECT));
 	}
 
+	@Test
+	@DisplayName("[성공] 알림 메세지를 읽음 처리한다.")
+	public void read() {
+		//given
+		String content = "밥먹자";
+		Notification notification = new Notification(content, false, 1L, NotificationType.CONNECT);
+		assertEquals(false, notification.getIsRead());
+
+		//when
+		notification.read();
+
+		//then
+		assertEquals(true, notification.getIsRead());
+	}
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/notification/repository/EmitterRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/notification/repository/EmitterRepositoryTest.java
@@ -76,7 +76,7 @@ class EmitterRepositoryTest {
 		emitterRepository.save(emitterId3, new SseEmitter(DEFAULT_TIMEOUT));
 
 		//when
-		Map<String, SseEmitter> ActualResult = emitterRepository.findAllStartWithById(String.valueOf(1L));
+		Map<String, SseEmitter> ActualResult = emitterRepository.findAllStartWithById(String.valueOf(10L));
 
 		//then
 		Assertions.assertEquals(3, ActualResult.size());

--- a/src/test/java/com/prgrms/mukvengers/domain/notification/repository/EmitterRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/notification/repository/EmitterRepositoryTest.java
@@ -1,0 +1,166 @@
+package com.prgrms.mukvengers.domain.notification.repository;
+
+import static com.prgrms.mukvengers.domain.notification.model.vo.NotificationType.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.prgrms.mukvengers.domain.notification.model.Notification;
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.domain.user.repository.UserRepository;
+import com.prgrms.mukvengers.utils.NotificationObjectProvider;
+import com.prgrms.mukvengers.utils.UserObjectProvider;
+
+@SpringBootTest
+class EmitterRepositoryTest {
+
+	@Autowired
+	private EmitterRepository emitterRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	private Long DEFAULT_TIMEOUT = 60L * 1000L * 60L;
+	private User user;
+
+	@BeforeEach
+	void setup() {
+		user = UserObjectProvider.createUser();
+		userRepository.save(user);
+	}
+
+	@Test
+	@DisplayName("[성공] 새로운 Emitter를 추가한다.")
+	public void save() throws Exception {
+		//given
+		Long memberId = 1L;
+		String emitterId = memberId + "_" + System.currentTimeMillis();
+		SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+
+		//when, then
+		Assertions.assertDoesNotThrow(() -> emitterRepository.save(emitterId, sseEmitter));
+	}
+
+	@Test
+	@DisplayName("[성공] 수신한 이벤트를 캐시에 저장한다.")
+	public void saveEventCache() {
+		//given
+		String eventCacheId = user.getId() + "_" + System.currentTimeMillis();
+		Notification notification = NotificationObjectProvider.createNotification("알람왔어요", user.getId(), INFO);
+
+		//when, then
+		Assertions.assertDoesNotThrow(() -> emitterRepository.saveEventCache(eventCacheId, notification));
+	}
+
+	@Test
+	@DisplayName("[성공] 특정 회원의 모든 Emitter를 찾는다")
+	public void findAllEmitterStartWithByMemberId() throws Exception {
+		//given
+		Long memberId = 10L;
+		String emitterId1 = memberId + "_" + System.currentTimeMillis();
+		emitterRepository.save(emitterId1, new SseEmitter(DEFAULT_TIMEOUT));
+
+		Thread.sleep(100);
+		String emitterId2 = memberId + "_" + System.currentTimeMillis();
+		emitterRepository.save(emitterId2, new SseEmitter(DEFAULT_TIMEOUT));
+
+		Thread.sleep(100);
+		String emitterId3 = memberId + "_" + System.currentTimeMillis();
+		emitterRepository.save(emitterId3, new SseEmitter(DEFAULT_TIMEOUT));
+
+		//when
+		Map<String, SseEmitter> ActualResult = emitterRepository.findAllStartWithById(String.valueOf(1L));
+
+		//then
+		Assertions.assertEquals(3, ActualResult.size());
+	}
+
+	@Test
+	@DisplayName("[성공] 회원에게 수신된 이벤트를 캐시에서 모두 찾는다.")
+	public void findAllEventCacheStartWithByMemberId() throws Exception {
+		//given
+		Long memberId = 1L;
+		String eventCacheId1 = memberId + "_" + System.currentTimeMillis();
+		Notification notification1 = NotificationObjectProvider.createNotification("알람1", user.getId(), INFO);
+		emitterRepository.saveEventCache(eventCacheId1, notification1);
+
+		Thread.sleep(100);
+		String eventCacheId2 = memberId + "_" + System.currentTimeMillis();
+		Notification notification2 = NotificationObjectProvider.createNotification("알람2", user.getId(), INFO);
+		emitterRepository.saveEventCache(eventCacheId2, notification2);
+
+		Thread.sleep(100);
+		String eventCacheId3 = memberId + "_" + System.currentTimeMillis();
+		Notification notification3 = NotificationObjectProvider.createNotification("알람3", user.getId(), INFO);
+		emitterRepository.saveEventCache(eventCacheId3, notification3);
+
+		//when
+		Map<String, Object> ActualResult = emitterRepository.findAllEventCacheStartWithId(String.valueOf(memberId));
+
+		//then
+		Assertions.assertEquals(3, ActualResult.size());
+	}
+
+	@Test
+	@DisplayName("[성공] ID를 통해 Emitter를 Repository에서 제거한다.")
+	public void deleteById() {
+		//given
+		Long memberId = 1L;
+		String emitterId = memberId + "_" + System.currentTimeMillis();
+		SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+
+		//when
+		emitterRepository.save(emitterId, sseEmitter);
+		emitterRepository.deleteById(emitterId);
+
+		//then
+		Assertions.assertEquals(0, emitterRepository.findAllStartWithById(emitterId).size());
+	}
+
+	@Test
+	@DisplayName("[성공] 저장된 모든 Emitter를 제거한다.")
+	public void deleteAllEmitterStartWithId() throws Exception {
+		//given
+		Long memberId = 1L;
+		String emitterId1 = memberId + "_" + System.currentTimeMillis();
+		emitterRepository.save(emitterId1, new SseEmitter(DEFAULT_TIMEOUT));
+
+		Thread.sleep(100);
+		String emitterId2 = memberId + "_" + System.currentTimeMillis();
+		emitterRepository.save(emitterId2, new SseEmitter(DEFAULT_TIMEOUT));
+
+		//when
+		emitterRepository.deleteAllStartWithId(String.valueOf(memberId));
+
+		//then
+		Assertions.assertEquals(0, emitterRepository.findAllStartWithById(String.valueOf(memberId)).size());
+	}
+
+	@Test
+	@DisplayName("[성공] 수신한 이벤트를 캐시에 저장한다.")
+	public void deleteAllEventCacheStartWithId() throws Exception {
+		//given
+		Long memberId = 1L;
+		String eventCacheId1 = memberId + "_" + System.currentTimeMillis();
+		Notification notification1 = NotificationObjectProvider.createNotification("알람1", user.getId(), INFO);
+		emitterRepository.saveEventCache(eventCacheId1, notification1);
+
+		Thread.sleep(100);
+		String eventCacheId2 = memberId + "_" + System.currentTimeMillis();
+		Notification notification2 = NotificationObjectProvider.createNotification("알람1", user.getId(), INFO);
+		emitterRepository.saveEventCache(eventCacheId2, notification2);
+
+		//when
+		emitterRepository.deleteAllEventCacheStartWithId(String.valueOf(memberId));
+
+		//then
+		Assertions.assertEquals(0, emitterRepository.findAllEventCacheStartWithId(String.valueOf(memberId)).size());
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,32 @@
+package com.prgrms.mukvengers.domain.notification.repository;
+
+import static com.prgrms.mukvengers.domain.notification.model.vo.NotificationType.*;
+import static com.prgrms.mukvengers.utils.NotificationObjectProvider.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.prgrms.mukvengers.base.RepositoryTest;
+import com.prgrms.mukvengers.domain.notification.model.Notification;
+
+class NotificationRepositoryTest extends RepositoryTest {
+
+	@Test
+	@DisplayName("[성공] 회원 ID로 해당 회원에게 발송된 알림을 전부 조회할 수 있다")
+	void findNotification_receiverId_success() {
+		//given
+		Notification notification1 = createNotification("알림1", savedUser1.getId(), INFO);
+		Notification notification2 = createNotification("거절당했어용", savedUser1.getId(), REJECT);
+		notificationRepository.save(notification1);
+		notificationRepository.save(notification2);
+
+		//when
+		List<Notification> result = notificationRepository.findAllByReceiverId(savedUser1Id);
+
+		//then
+		Assertions.assertEquals(2, result.size());
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,117 @@
+package com.prgrms.mukvengers.domain.notification.service;
+
+import static com.prgrms.mukvengers.domain.notification.model.vo.NotificationType.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.prgrms.mukvengers.base.ServiceTest;
+import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponses;
+import com.prgrms.mukvengers.domain.notification.exception.NotificationNotFoundException;
+import com.prgrms.mukvengers.domain.notification.model.Notification;
+import com.prgrms.mukvengers.domain.user.exception.UserNotFoundException;
+import com.prgrms.mukvengers.domain.user.repository.UserRepository;
+import com.prgrms.mukvengers.utils.NotificationObjectProvider;
+
+class NotificationServiceTest extends ServiceTest {
+
+	@Autowired
+	private NotificationService notificationService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("[성공] 알림 구독을 진행한다.")
+	public void subscribe() {
+		//given
+		String lastEventId = "";
+
+		//when, then
+		Assertions.assertDoesNotThrow(() ->
+			notificationService.subscribe(savedUser1.getId(), lastEventId));
+	}
+
+	@Test
+	@DisplayName("[성공] 알림 메세지를 전송한다.")
+	public void send() {
+		//given
+		String lastEventId = "";
+		notificationService.subscribe(savedUser1.getId(), lastEventId);
+
+		//when, then
+		Assertions.assertDoesNotThrow(() -> notificationService.send(savedUser1.getId(), "알림 발송!!!", INFO));
+	}
+
+	@Test
+	@DisplayName("[성공] 알림 메세지를 저장한다.")
+	public void save() {
+		//given
+		Notification noti = NotificationObjectProvider.createNotification("신촌으로 모여!", savedUser1.getId(),
+			INFO);
+
+		//when
+		Notification savedOne = notificationService.save(noti.getReceiverId(), noti.getContent().getContent(),
+			noti.getType());
+
+		//then
+		assertEquals(noti.getType(), savedOne.getType());
+		assertEquals(noti.getReceiverId(), savedOne.getReceiverId());
+		assertEquals(noti.getContent().getContent(), savedOne.getContent().getContent());
+	}
+
+	@Test
+	@DisplayName("[성공] 알림 메세지를 읽음 처리한다.")
+	public void read() {
+		//given
+		Notification notification = notificationService.save(savedUser1.getId(), "신촌으로 모여!", INFO);
+		assertEquals(false, notification.getIsRead());
+
+		//when
+		notificationService.readNotification(notification.getId());
+
+		//then
+		assertEquals(true, notification.getIsRead());
+	}
+
+	@Test
+	@DisplayName("[실패] 존재하지 않는 알림 ID를 조회할 경우 예외가 발생한다.")
+	public void read_fail() {
+		//given
+		Notification notification = notificationService.save(savedUser1.getId(), "신촌으로 모여!", INFO);
+		Long unknownId = 100L;
+
+		//when & then
+		assertThrows(NotificationNotFoundException.class, () -> notificationService.readNotification(unknownId));
+	}
+
+	@Test
+	@DisplayName("[성공] 회원 ID로 알림을 조회할 수 있다.")
+	public void findByReceiverId() {
+		//given
+		notificationService.save(savedUser1.getId(), "1번 알림", INFO);
+		notificationService.save(savedUser1.getId(), "2번 알림", APPROVE);
+		notificationService.save(savedUser1.getId(), "3번 알림", REJECT);
+
+		//when
+		NotificationResponses result = notificationService.findAllById(savedUser1.getId());
+
+		//then
+		assertEquals(3, result.notifications().size());
+	}
+
+	@Test
+	@DisplayName("[실패] 존재하지 않는 회원 ID로 알림을 조회 시 예외가 발생한다.")
+	public void findByReceiverId_fail() {
+		//given
+		notificationService.save(savedUser1.getId(), "1번 알림", INFO);
+
+		Long unknownId = 100L;
+
+		//when & then
+		assertThrows(UserNotFoundException.class, () -> notificationService.findAllById(unknownId));
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/notification/service/NotificationServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.prgrms.mukvengers.base.ServiceTest;
 import com.prgrms.mukvengers.domain.notification.dto.response.NotificationResponses;
+import com.prgrms.mukvengers.domain.notification.exception.InvalidNotificationAccessException;
 import com.prgrms.mukvengers.domain.notification.exception.NotificationNotFoundException;
 import com.prgrms.mukvengers.domain.notification.model.Notification;
 import com.prgrms.mukvengers.domain.user.exception.UserNotFoundException;
@@ -71,7 +72,7 @@ class NotificationServiceTest extends ServiceTest {
 		assertEquals(false, notification.getIsRead());
 
 		//when
-		notificationService.readNotification(notification.getId());
+		notificationService.readNotification(savedUser1.getId(), notification.getId());
 
 		//then
 		assertEquals(true, notification.getIsRead());
@@ -85,7 +86,8 @@ class NotificationServiceTest extends ServiceTest {
 		Long unknownId = 100L;
 
 		//when & then
-		assertThrows(NotificationNotFoundException.class, () -> notificationService.readNotification(unknownId));
+		assertThrows(NotificationNotFoundException.class,
+			() -> notificationService.readNotification(savedUser1.getId(), unknownId));
 	}
 
 	@Test
@@ -113,5 +115,16 @@ class NotificationServiceTest extends ServiceTest {
 
 		//when & then
 		assertThrows(UserNotFoundException.class, () -> notificationService.findAllById(unknownId));
+	}
+
+	@Test
+	@DisplayName("[실패] 읽음 처리를 요청한 회원과 알림의 수신자가 동일하지 않은 경우 예외가 발생한다.")
+	public void read_fail2() {
+		//given
+		Notification notification = notificationService.save(savedUser1.getId(), "1번 알림", INFO);
+		Long anotherUserId = savedUser2.getId();
+		//when & then
+		assertThrows(InvalidNotificationAccessException.class,
+			() -> notificationService.readNotification(anotherUserId, notification.getId()));
 	}
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/notification/util/NotificationFactoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/notification/util/NotificationFactoryTest.java
@@ -1,0 +1,35 @@
+package com.prgrms.mukvengers.domain.notification.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.prgrms.mukvengers.domain.notification.model.Notification;
+import com.prgrms.mukvengers.domain.notification.model.vo.NotificationType;
+
+@SpringBootTest
+class NotificationFactoryTest {
+
+	@Autowired
+	private NotificationFactory factory;
+
+	@Test
+	@DisplayName("[성공] 알림이 정상 생성된다.")
+	public void create() {
+		//given
+		Long receiverId = 1L;
+		String content = "알림이요";
+		NotificationType type = NotificationType.INFO;
+
+		//when
+		Notification notification = factory.createNotification(receiverId, content, type);
+
+		//then
+		assertEquals(receiverId, notification.getReceiverId());
+		assertEquals(content, notification.getContent().getContent());
+		assertEquals(type, notification.getType());
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/utils/NotificationObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/NotificationObjectProvider.java
@@ -1,0 +1,25 @@
+package com.prgrms.mukvengers.utils;
+
+import com.prgrms.mukvengers.domain.notification.model.Notification;
+import com.prgrms.mukvengers.domain.notification.model.vo.NotificationType;
+
+public class NotificationObjectProvider {
+
+	public static Notification createNotification(String content, Long receiverId, NotificationType type) {
+		return Notification.builder()
+			.content(content)
+			.isRead(false)
+			.receiverId(receiverId)
+			.type(type)
+			.build();
+	}
+
+	public static Notification createNotification(String content, Long receiverId) {
+		return Notification.builder()
+			.content(content)
+			.isRead(false)
+			.receiverId(receiverId)
+			.type(NotificationType.INFO)
+			.build();
+	}
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -2,6 +2,7 @@
 -- create schema mukvengers
 -- use mukvengers;
 
+DROP TABLE IF EXISTS notification;
 DROP TABLE IF EXISTS chat;
 DROP TABLE IF EXISTS comment;
 DROP TABLE IF EXISTS post;
@@ -128,4 +129,19 @@ CREATE TABLE chat
     deleted    boolean      NOT NULL DEFAULT false
 );
 
+CREATE TABLE notification
+(
+    id          bigint       NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    content     varchar(255) NOT NULL,
+    type        varchar(255) NOT NULL,
+    is_read     boolean      NOT NULL DEFAULT false,
+    receiver_id bigint       NOT NULL,
+    created_at  dateTime     NOT NULL DEFAULT now(),
+    updated_at  dateTime     NOT NULL DEFAULT now(),
+    deleted     boolean      NOT NULL DEFAULT false
+);
+
 create index idx_crew_id on chat (crew_id);
+# receiver_id 인덱스 추가
+create index idx_receiver_id on notification (receiver_id);
+


### PR DESCRIPTION
### 🌱 작업 사항 
SSE를 이용했습니다. 
알림 기능의 경우 양방향 통신이 불필요하며, 별도의 프로토콜 없이 HTTP만 사용하므로 소켓에 비해 훨씬 가볍습니다.

Spring이 SseEmitter를 제공해 준 덕분에 SSE는 쉽게 구현할 수 있습니다.

통신과정을 요약하면
1. 클라이언트에서 SSE 연결 요청을 보낸다.
2. 서버에서는 클라이언트와 매핑되는 SSE 통신 객체(SseEmitter)를 만든다.
3. 서버에서 이벤트가 발생하면 해당 객체(SseEmitter)를 통해 클라이언트로 데이터를 전달한다.
입니다.

많이 부족하지만 질문있으시면 성심껏 답변해드립니다. 
개선할 수 있는 부분도 말씀해주시면 감사하겠습니다 (_ _)

### 🦄 관련 이슈
- resolves #211


