### PR TITLE
[#205] 채팅 테스트

### DIFF
--- a/src/test/java/com/prgrms/mukvengers/domain/chat/api/ChatControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/chat/api/ChatControllerTest.java
@@ -1,0 +1,163 @@
+package com.prgrms.mukvengers.domain.chat.api;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static com.epages.restdocs.apispec.ResourceSnippetParameters.*;
+import static com.prgrms.mukvengers.utils.ChatObjectProvider.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import com.epages.restdocs.apispec.Schema;
+import com.prgrms.mukvengers.base.ControllerTest;
+import com.prgrms.mukvengers.domain.chat.dto.request.ChatRequest;
+import com.prgrms.mukvengers.domain.chat.service.ChatService;
+
+class ChatControllerTest extends ControllerTest {
+
+	private static final String CHAT = "채팅 API";
+	private static final Schema GET_CHAT_RESPONSE = new Schema("getChatResponse");
+
+	@Autowired
+	private ChatService chatService;
+
+	@BeforeEach
+	void setUp() {
+		Map<String, Object> simpSessionAttributes = new HashMap<>();
+		simpSessionAttributes.put("username", "testUser");
+		simpSessionAttributes.put("profileImgUrl", "testProfileImgUrl");
+		ChatRequest chatRequest = createChatRequest(savedUser1Id);
+		for (int i = 0; i < 10; i++) {
+			chatService.save(chatRequest, 1L, simpSessionAttributes);
+		}
+	}
+
+	@Test
+	@DisplayName("[성공] 채팅 내역을 불러올 수 있다 - v2 : 페이지네이션 버전")
+	void getChattingListV2Test_success() throws Exception {
+
+		mockMvc.perform(get("/api/v2/crews/{crewId}/chats", 1L)
+				.queryParam("page", "0")
+				.queryParam("size", "10")
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken1)
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.chats.content[0].id").exists())
+			.andExpect(jsonPath("$.data.chats.content[0].userId").exists())
+			.andExpect(jsonPath("$.data.chats.content[0].username").exists())
+			.andExpect(jsonPath("$.data.chats.content[0].profileImgUrl").exists())
+			.andExpect(jsonPath("$.data.chats.content[0].type").exists())
+			.andExpect(jsonPath("$.data.chats.content[0].createdAt").exists())
+			.andExpect(jsonPath("$.data.chats.content[0].content").exists())
+			.andDo(print())
+			.andDo(document("채팅방 내역 조회 - V2",
+				resource(
+					builder()
+						.tag(CHAT)
+						.summary("채팅방 조회 API")
+						.description("채팅방 내의 대화 내역 조회합니다. v2의 경우는 페이지네이션이 적용되어 있습니다.")
+						.pathParameters(
+							parameterWithName("crewId").description("조회할 채팅방 번호 - 모임 아이디"))
+						.requestParameters(
+							parameterWithName("page").description("조회할 페이지 번호"),
+							parameterWithName("size").description("조회할 페이지 사이즈"))
+						.responseFields(
+							fieldWithPath("data.chats.content[].id").type(JsonFieldType.NUMBER).description("채팅방 아이디"),
+							fieldWithPath("data.chats.content[].userId").type(JsonFieldType.NUMBER)
+								.description("유저 아이디"),
+							fieldWithPath("data.chats.content[].username").type(JsonFieldType.STRING)
+								.description("유저 이름"),
+							fieldWithPath("data.chats.content[].profileImgUrl").type(JsonFieldType.STRING)
+								.description("프로필 이미지 url"),
+							fieldWithPath("data.chats.content[].type").type(JsonFieldType.STRING).description("메시지 타입"),
+							fieldWithPath("data.chats.content[].createdAt").type(JsonFieldType.ARRAY)
+								.description("메시지 생성 시간"),
+							fieldWithPath("data.chats.content[].content").type(JsonFieldType.STRING)
+								.description("채팅 내용"),
+							fieldWithPath("data.chats.pageable.sort.empty").type(JsonFieldType.BOOLEAN)
+								.description("빈 페이지 여부"),
+							fieldWithPath("data.chats.pageable.sort.sorted").type(JsonFieldType.BOOLEAN)
+								.description("페이지 정렬 여부"),
+							fieldWithPath("data.chats.pageable.sort.unsorted").type(JsonFieldType.BOOLEAN)
+								.description("페이지 비정렬 여부"),
+							fieldWithPath("data.chats.pageable.offset").type(JsonFieldType.NUMBER)
+								.description("페이지 오프셋"),
+							fieldWithPath("data.chats.pageable.pageNumber").type(JsonFieldType.NUMBER)
+								.description("페이지 번호"),
+							fieldWithPath("data.chats.pageable.pageSize").type(JsonFieldType.NUMBER)
+								.description("한 페이지에 나타내는 원소 수"),
+							fieldWithPath("data.chats.pageable.paged").type(JsonFieldType.BOOLEAN)
+								.description("페이지 정보 포함 여부"),
+							fieldWithPath("data.chats.pageable.unpaged").type(JsonFieldType.BOOLEAN)
+								.description("페이지 정보 비포함 여부"),
+							fieldWithPath("data.chats.last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+							fieldWithPath("data.chats.size").type(JsonFieldType.NUMBER).description("페이지 사이즈"),
+							fieldWithPath("data.chats.number").type(JsonFieldType.NUMBER).description("페이지 번호"),
+							fieldWithPath("data.chats.sort.empty").type(JsonFieldType.BOOLEAN).description("빈 페이지 여부"),
+							fieldWithPath("data.chats.sort.sorted").type(JsonFieldType.BOOLEAN)
+								.description("페이지 정렬 여부"),
+							fieldWithPath("data.chats.sort.unsorted").type(JsonFieldType.BOOLEAN)
+								.description("페이지 비정렬 여부"),
+							fieldWithPath("data.chats.first").type(JsonFieldType.BOOLEAN).description("첫 번째 페이지 여부"),
+							fieldWithPath("data.chats.numberOfElements").type(JsonFieldType.NUMBER)
+								.description("페이지 원소 개수"),
+							fieldWithPath("data.chats.empty").type(JsonFieldType.BOOLEAN).description("빈 페이지 여부"),
+							fieldWithPath("data.chats.totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 개수"),
+							fieldWithPath("data.chats.totalElements").type(JsonFieldType.NUMBER)
+								.description("전체 데이터 개수"))
+						.responseSchema(GET_CHAT_RESPONSE)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("[성공] 채팅 내역을 불러올 수 있다 - V1 : 일반 버전")
+	void getChattingListV1Test_success() throws Exception {
+
+		mockMvc.perform(get("/api/v1/crews/{crewId}/chats", 1L)
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken1))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.chats[0].id").exists())
+			.andExpect(jsonPath("$.data.chats[0].userId").exists())
+			.andExpect(jsonPath("$.data.chats[0].username").exists())
+			.andExpect(jsonPath("$.data.chats[0].profileImgUrl").exists())
+			.andExpect(jsonPath("$.data.chats[0].type").exists())
+			.andExpect(jsonPath("$.data.chats[0].createdAt").exists())
+			.andExpect(jsonPath("$.data.chats[0].content").exists())
+			.andDo(print())
+			.andDo(document("채팅방 내역 조회 - V1",
+				resource(
+					builder()
+						.tag(CHAT)
+						.summary("채팅방 조회 API")
+						.description("채팅방 내의 대화 내역 조회합니다. v2의 경우는 페이지네이션이 적용되어 있습니다.")
+						.pathParameters(
+							parameterWithName("crewId").description("조회할 채팅방 번호 - 모임 아이디"))
+						.responseFields(
+							fieldWithPath("data.chats[].id").type(JsonFieldType.NUMBER).description("채팅방 아이디"),
+							fieldWithPath("data.chats[].userId").type(JsonFieldType.NUMBER).description("유저 아이디"),
+							fieldWithPath("data.chats[].username").type(JsonFieldType.STRING).description("유저 이름"),
+							fieldWithPath("data.chats[].profileImgUrl").type(JsonFieldType.STRING)
+								.description("프로필 이미지 url"),
+							fieldWithPath("data.chats[].type").type(JsonFieldType.STRING).description("메시지 타입"),
+							fieldWithPath("data.chats[].createdAt").type(JsonFieldType.ARRAY).description("메시지 생성 시간"),
+							fieldWithPath("data.chats[].content").type(JsonFieldType.STRING).description("채팅 내용"))
+						.responseSchema(GET_CHAT_RESPONSE)
+						.build()
+				)
+			));
+	}
+
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/chat/handler/StompHandlerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/chat/handler/StompHandlerTest.java
@@ -1,0 +1,143 @@
+package com.prgrms.mukvengers.domain.chat.handler;
+
+import static com.prgrms.mukvengers.domain.chat.handler.StompHandler.*;
+import static com.prgrms.mukvengers.utils.CrewMemberObjectProvider.*;
+import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
+import static com.prgrms.mukvengers.utils.StoreObjectProvider.*;
+import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import com.prgrms.mukvengers.base.SliceTest;
+import com.prgrms.mukvengers.domain.crew.model.Crew;
+import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
+import com.prgrms.mukvengers.domain.crewmember.model.vo.CrewMemberRole;
+import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
+import com.prgrms.mukvengers.domain.store.model.Store;
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.domain.user.repository.UserRepository;
+import com.prgrms.mukvengers.global.security.token.service.JwtTokenProvider;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.impl.DefaultClaims;
+
+class StompHandlerTest extends SliceTest {
+
+	private static final String MESSAGE = "testMessage";
+	private static final String ACCESS_TOKEN = "accessToken";
+
+	private final Map<String, Object> header = new HashMap<>();
+	private final Map<String, Object> sessionAttributes = new HashMap<>();
+	private final Map<String, List<String>> nativeHeaders = new HashMap<>();
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private CrewMemberRepository crewMemberRepository;
+
+	@InjectMocks
+	private StompHandler stompHandler;
+
+	@Test
+	@DisplayName("[성공] CONNECT 메시지를 보낼 때, access 토큰이 유효하면 user 정보를 세션 맵에 저장한다.")
+	void preSend_connect_test_success() {
+		// Given
+		User user = createUser();
+
+		Map<String, Long> userInfo = new HashMap<>();
+		userInfo.put("userId", user.getId());
+		Claims claims = new DefaultClaims(userInfo);
+
+		sessionAttributes.put("userId", user.getId());
+		nativeHeaders.put(HttpHeaders.AUTHORIZATION, List.of("Bearer " + ACCESS_TOKEN));
+
+		willDoNothing().given(jwtTokenProvider).validateToken(ACCESS_TOKEN);
+		given(jwtTokenProvider.getClaims(ACCESS_TOKEN)).willReturn(claims);
+		given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+		// When
+		Message<?> sendMessage = setTestMessage(StompCommand.CONNECT);
+		Message<?> resultMessage = stompHandler.preSend(sendMessage, null);
+
+		// Then
+		StompHeaderAccessor resultHeaderAccessor = StompHeaderAccessor.wrap(resultMessage);
+		assertThat(resultHeaderAccessor.getCommand()).isEqualTo(StompCommand.CONNECT);
+		assertThat(resultHeaderAccessor.getSessionAttributes()).isNotNull();
+		assertThat(resultHeaderAccessor.getSessionAttributes())
+			.containsEntry("userId", user.getId())
+			.containsEntry("username", user.getNickname())
+			.containsEntry("profileImgUrl", user.getProfileImgUrl());
+	}
+
+	@Test
+	@DisplayName("[성공] SUBSCRIBE 메시지를 보낼 때, 목적지를 통해 Crew 정보를 검증하고 crewId 정보를 세션 맵에 저장한다.")
+	void preSend_subscribe_test_success() {
+		// Given
+		Store store = createStore();
+		Crew crew = createCrew(store);
+		CrewMember crewMember = createCrewMember(1L, crew, CrewMemberRole.LEADER);
+		Long crewId = 123L;
+
+		sessionAttributes.put("userId", 1L);
+		header.put("simpDestination", DEFAULT_PATH + crewId);
+
+		given(crewMemberRepository.findCrewMemberByCrewIdAndUserId(crewId, 1L))
+			.willReturn(Optional.of(crewMember));
+
+		// When
+		Message<?> sendMessage = setTestMessage(StompCommand.SUBSCRIBE);
+		Message<?> resultMessage = stompHandler.preSend(sendMessage, null);
+
+		// Then
+		StompHeaderAccessor resultHeaderAccessor = StompHeaderAccessor.wrap(resultMessage);
+		assertThat(resultHeaderAccessor.getCommand()).isEqualTo(StompCommand.SUBSCRIBE);
+		assertThat(resultHeaderAccessor.getSessionAttributes()).isNotNull();
+		assertThat(resultHeaderAccessor.getSessionAttributes().get("crewId")).isNotNull();
+	}
+
+	@Test
+	@DisplayName("[성공] DISCONNECT 메시지를 보낼 때, user 정보를 로그로 출력한다,")
+	void preSend_disconnect_test_success() {
+		// Given
+		sessionAttributes.put("userId", 1L);
+
+		// When
+		Message<?> sendMessage = setTestMessage(StompCommand.DISCONNECT);
+		Message<?> resultMessage = stompHandler.preSend(sendMessage, null);
+
+		// Then
+		StompHeaderAccessor resultHeaderAccessor = StompHeaderAccessor.wrap(resultMessage);
+		assertThat(resultHeaderAccessor.getCommand()).isEqualTo(StompCommand.DISCONNECT);
+	}
+
+	private Message<?> setTestMessage(StompCommand command) {
+
+		header.put("simpSessionAttributes", sessionAttributes);
+		header.put("nativeHeaders", nativeHeaders);
+		header.put("stompCommand", command);
+
+		MessageHeaders messageHeaders = new MessageHeaders(header);
+
+		return MessageBuilder.createMessage(MESSAGE, messageHeaders);
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/chat/handler/WebSocketEventListenerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/chat/handler/WebSocketEventListenerTest.java
@@ -1,0 +1,119 @@
+package com.prgrms.mukvengers.domain.chat.handler;
+
+import static org.mockito.BDDMockito.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import com.prgrms.mukvengers.base.ControllerTest;
+import com.prgrms.mukvengers.domain.chat.dto.request.ChatRequest;
+import com.prgrms.mukvengers.domain.chat.dto.request.MessageType;
+
+@SpringBootTest
+class WebSocketEventListenerTest extends ControllerTest {
+
+	private static final String MESSAGE = "testMessage";
+
+	private final Map<String, Object> header = new HashMap<>();
+	private final Map<String, Object> sessionAttributes = new HashMap<>();
+	private final Map<String, List<String>> nativeHeaders = new HashMap<>();
+
+	@Autowired
+	private ApplicationEventPublisher eventPublisher;
+
+	@MockBean
+	private SimpMessagingTemplate simpMessagingTemplate;
+
+	private SessionConnectedEvent sessionConnectedEvent;
+	private SessionSubscribeEvent sessionSubscribeEvent;
+	private SessionDisconnectEvent sessionDisconnectEvent;
+
+	@Test
+	@DisplayName("웹소켓 연결 시 이벤트 발생")
+	void handleWebSocketConnectListenerTest() {
+		// Given
+		sessionAttributes.put("userId", savedUser1.getId());
+		nativeHeaders.put(HttpHeaders.AUTHORIZATION, List.of("Bearer " + accessToken1));
+
+		// When
+		sessionConnectedEvent = new SessionConnectedEvent(this, setTestMessage(StompCommand.CONNECTED));
+		eventPublisher.publishEvent(sessionConnectedEvent);
+
+		// Then
+		then(simpMessagingTemplate).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("웹소켓 구독 시 이벤트 발생")
+	void handleWebSocketSubscribeListenerTest() {
+		// Given
+		Long crewId = 123L;
+		String defaultPath = "/topic/public/";
+		ChatRequest chatRequest = new ChatRequest(MessageType.JOIN, savedUser1.getId(),
+			savedUser1.getNickname() + " 님이 입장했습니다.");
+
+		sessionAttributes.put("userId", savedUser1.getId());
+		sessionAttributes.put("username", savedUser1.getNickname());
+		sessionAttributes.put("crewId", 123L);
+
+		// When
+		sessionSubscribeEvent = new SessionSubscribeEvent(this, setTestMessage(StompCommand.SUBSCRIBE));
+		eventPublisher.publishEvent(sessionSubscribeEvent);
+
+		// Then
+		then(simpMessagingTemplate).should().convertAndSend(defaultPath + crewId, chatRequest);
+	}
+
+	@Test
+	@DisplayName("웹소켓 연결 해제 시 이벤트 발생")
+	void handleWebSocketDisconnectListenerTest() {
+		// Given
+		Long crewId = 123L;
+		String defaultPath = "/topic/public/";
+		ChatRequest chatRequest = new ChatRequest(
+			MessageType.LEAVE, savedUser1.getId(), savedUser1.getNickname() + " 님이 떠났습니다.");
+
+		sessionAttributes.put("userId", savedUser1.getId());
+		sessionAttributes.put("username", savedUser1.getNickname());
+		sessionAttributes.put("crewId", 123L);
+
+		// When
+		sessionDisconnectEvent = new SessionDisconnectEvent(this, setTestMessage(StompCommand.DISCONNECT),
+			"testSessionId", CloseStatus.NORMAL);
+		eventPublisher.publishEvent(sessionDisconnectEvent);
+
+		// Then
+		then(simpMessagingTemplate).should().convertAndSend(defaultPath + crewId, chatRequest);
+	}
+
+	private Message<byte[]> setTestMessage(StompCommand command) {
+
+		header.put("simpSessionAttributes", sessionAttributes);
+		header.put("simpSessionId", "testSessionId"); //
+		header.put("nativeHeaders", nativeHeaders);
+		header.put("stompCommand", command);
+
+		MessageHeaders messageHeaders = new MessageHeaders(header);
+
+		return MessageBuilder.createMessage(MESSAGE.getBytes(StandardCharsets.UTF_8), messageHeaders);
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/utils/ChatObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/ChatObjectProvider.java
@@ -1,12 +1,24 @@
 package com.prgrms.mukvengers.utils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.prgrms.mukvengers.domain.chat.dto.request.ChatRequest;
 import com.prgrms.mukvengers.domain.chat.dto.request.MessageType;
+import com.prgrms.mukvengers.domain.chat.dto.response.ChatResponse;
+import com.prgrms.mukvengers.domain.chat.dto.response.ChatResponses;
+import com.prgrms.mukvengers.domain.chat.dto.response.ChatsInCrew;
 import com.prgrms.mukvengers.domain.chat.model.Chat;
+import com.prgrms.mukvengers.domain.user.model.User;
 
 public class ChatObjectProvider {
+
+	public static final String TEST_MESSAGE = "testMessage";
 
 	public static Chat getChat(Long crewId, Long userId, String content) {
 		return Chat.builder()
@@ -26,5 +38,46 @@ public class ChatObjectProvider {
 				.content("content" + i)
 				.type(MessageType.CHAT)
 				.build()).toList();
+	}
+
+	public static ChatsInCrew createChatsInCrew(ChatResponse chatResponse) {
+		Page<ChatResponse> chatResponseInPage = new PageImpl<>(List.of(chatResponse), Pageable.unpaged(), 1);
+		return new ChatsInCrew(chatResponseInPage);
+	}
+
+	public static ChatsInCrew createChatsInCrew(ChatResponses chatResponses) {
+		Page<ChatResponse> chatResponseInPage = new PageImpl<>(chatResponses.chats(), Pageable.unpaged(), 1);
+		return new ChatsInCrew(chatResponseInPage);
+	}
+
+	public static ChatsInCrew createChatsInCrew(List<ChatResponse> chatResponses) {
+		Page<ChatResponse> chatResponseInPage = new PageImpl<>(chatResponses, Pageable.unpaged(), 1);
+		return new ChatsInCrew(chatResponseInPage);
+	}
+
+	public static ChatResponses createChatResponses() {
+		return new ChatResponses(createChatResponseList());
+	}
+
+	public static List<ChatResponse> createChatResponseList() {
+		return List.of(createChatResponse());
+	}
+
+	public static ChatResponse createChatResponse(User user) {
+		return new ChatResponse(1L, user.getId(), user.getNickname(), user.getProfileImgUrl(),
+			MessageType.CHAT, LocalDateTime.now(), TEST_MESSAGE);
+	}
+
+	public static ChatResponse createChatResponse() {
+		return new ChatResponse(1L, 1L, "test", "https://example.com/testImage.jpg",
+			MessageType.CHAT, LocalDateTime.now(), TEST_MESSAGE);
+	}
+
+	public static ChatRequest createChatRequest() {
+		return createChatRequest(1L);
+	}
+
+	public static ChatRequest createChatRequest(Long userId) {
+		return new ChatRequest(MessageType.CHAT, userId, TEST_MESSAGE);
 	}
 }


### PR DESCRIPTION
### 🌱 작업 사항 
#### 이미 종료된 #205 를 보충하는 PR입니다.
- 채팅 내역 조회에 대한 API를 Restdocs로 테스트 했습니다.
- 채팅시에 인증 및 이벤트 처리에 대해 테스트 했습니다.
- 아직 웹소켓이 잘 안되서 이 부분은 이후에 추가하도록 하겠습니다.
### 🦄 관련 이슈
- resolves #205 



