### PR TITLE
[#221] Store내 병목 현상을 유발하는 코드 제거

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/store/model/Store.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/store/model/Store.java
@@ -5,11 +5,14 @@ import static javax.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 import static org.springframework.util.Assert.*;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import org.locationtech.jts.geom.Point;
@@ -24,6 +27,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Where(clause = "deleted = false")
+@DynamicUpdate
 @SQLDelete(sql = "UPDATE store set deleted = true where id=?")
 public class Store extends BaseEntity {
 
@@ -86,9 +90,12 @@ public class Store extends BaseEntity {
 	private Point validatePosition(Point location) {
 		notNull(location, "유효하지 않는 위치입니다.");
 
+		if (Objects.equals(this.location, location)) {
+			return this.location;
+		}
+
 		validateLongitude(location);
 		validateLatitude(location);
-
 		return location;
 	}
 


### PR DESCRIPTION
### 🌱 작업 사항 
- [refactor(Store): Store내 병목현상 제거](https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-BE/commit/d81b7ecd835ddbd1ab46c9023dbd14ea8f91cd66) 
  - Store를 Update 하는 과정에서 Point 객체의 값이 미묘하게 변하게 되어(내부적으로 Double을 가지고 있는데 아마, 부동소수점으로 인해 발생했을것으로 추측) 더티체킹으로 Update 쿼리가 나가는 현상이 발생함
  - 부하 테스트를 통해 문제를 발견했으며, 이를 @DynamicUpdate와 Objects.equals 비교를 통해 같은 값이면 현재 값을 사용할 수 있도록 했습니다

### 성능 테스트 결과

#### 기본 요청
- <img width="283" alt="스크린샷 2023-05-16 오후 6 01 19" src="https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-BE/assets/99165624/2e9499c2-e1a3-4d91-b309-b79021d37fb6">
- 100명의 사용자를 가정했고 1초(동시)에 요청을 보낸다고 가정했습니다. 

### 개선 전
- <img width="834" alt="스크린샷 2023-05-16 오후 6 01 09" src="https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-BE/assets/99165624/4e24ce7c-b55c-4e19-a79a-34d07487621d">
- 5번 정도 반복 진행했습니다. (실제 서버에 요청했습니다.)
- 보시다 시피 평균 오류가 30% 정도 입니다.
- 대부분의 오류는 트랜잭션에 의한 락으로 인해 발생된 것 입니다. (동시에 같은 값을 변경하고자 하는 요청이 너무 많아서..)

### 개선 후

<img width="844" alt="image" src="https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-BE/assets/99165624/cc994e7f-f3e8-447c-a5b2-4c92039d5826">

- 보시다시피 오류는 전혀 발생하지 않았습니다.

### ❓ 리뷰 포인트
- 이해 안가시는건 질문 바랍니다~!
### 🦄 관련 이슈
- #221 



