### PR TITLE
[#232] 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/user/api/UserController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/api/UserController.java
@@ -7,6 +7,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -62,9 +63,10 @@ public class UserController {
 	@DeleteMapping("/me")
 	@ResponseStatus(NO_CONTENT)
 	public void deleteMyProfile(
-		@AuthenticationPrincipal JwtAuthentication user
+		@AuthenticationPrincipal JwtAuthentication user,
+		@CookieValue("refreshToken") String refreshToken
 	) {
-		userService.deleteUser(user.id());
+		userService.deleteUser(user.id(), refreshToken);
 	}
 
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
@@ -7,6 +7,7 @@ import static org.springframework.util.Assert.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Objects;
+import java.util.Random;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -36,6 +37,7 @@ public class User extends BaseEntity {
 	public static final String DEFAULT_INTRODUCE = "자기소개를 작성해주세요";
 	public static final Integer ZERO = 0;
 	public static final BigDecimal CRITERIA = new BigDecimal("0.1");
+	private static final Random RANDOM = new Random();
 
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
@@ -110,6 +112,19 @@ public class User extends BaseEntity {
 		this.nickname = validateNickName(updateUserRequest.nickName());
 		this.profileImgUrl = validateProfileImgUrl(updateUserRequest.profileImgUrl());
 		this.introduction = validateIntroduction(updateUserRequest.introduction());
+		return this;
+	}
+
+	public User deleteInfo() {
+		this.nickname = "탈퇴한 유저";
+		this.profileImgUrl = "None";
+		this.introduction = "탈퇴한 유저입니다.";
+		this.provider = "NONE";
+		this.oauthId = "NONE : " + (this.id * RANDOM.nextInt(1000));
+		this.mannerScore = new BigDecimal("36.5");
+		this.tasteScore = ZERO;
+		this.leaderCount = ZERO;
+		this.crewCount = ZERO;
 		return this;
 	}
 

--- a/src/main/java/com/prgrms/mukvengers/domain/user/service/DefaultUserService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/service/DefaultUserService.java
@@ -12,6 +12,7 @@ import com.prgrms.mukvengers.domain.user.model.User;
 import com.prgrms.mukvengers.domain.user.repository.UserRepository;
 import com.prgrms.mukvengers.global.security.oauth.dto.AuthUserInfo;
 import com.prgrms.mukvengers.global.security.oauth.dto.OAuthUserInfo;
+import com.prgrms.mukvengers.global.security.token.service.TokenService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +25,7 @@ public class DefaultUserService implements UserService {
 
 	private final UserMapper userMapper;
 	private final UserRepository userRepository;
+	private final TokenService tokenService;
 
 	/* [회원 인증 정보 조회 및 저장] 등록된 유저 정보 찾아서 제공하고 없으면 등록합니다. */
 	@Override
@@ -64,12 +66,11 @@ public class DefaultUserService implements UserService {
 	/* [회원 탈퇴] 계정을 삭제합니다. soft delete가 적용됩니다.*/
 	@Override
 	@Transactional
-	public void deleteUser(Long userId) {
+	public void deleteUser(Long userId, String refreshToken) {
 		userRepository.findById(userId)
-			.ifPresentOrElse(userRepository::delete,
-				() -> {
-					throw new UserNotFoundException(userId);
-				});
+			.ifPresent(user -> {
+				user.deleteInfo();
+				tokenService.deleteRefreshToken(refreshToken);
+			});
 	}
-
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/user/service/DefaultUserService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/service/DefaultUserService.java
@@ -68,9 +68,11 @@ public class DefaultUserService implements UserService {
 	@Transactional
 	public void deleteUser(Long userId, String refreshToken) {
 		userRepository.findById(userId)
-			.ifPresent(user -> {
+			.ifPresentOrElse(user -> {
 				user.deleteInfo();
 				tokenService.deleteRefreshToken(refreshToken);
+			}, () -> {
+				throw new UserNotFoundException(userId);
 			});
 	}
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/service/UserService.java
@@ -7,7 +7,6 @@ import com.prgrms.mukvengers.global.security.oauth.dto.OAuthUserInfo;
 
 public interface UserService {
 
-
 	/* 회원 등록 */
 	AuthUserInfo getOrRegisterUser(OAuthUserInfo oauthUserInfo);
 
@@ -18,6 +17,6 @@ public interface UserService {
 	UserProfileResponse updateUserProfile(UpdateUserRequest updateUserRequest, Long userId);
 
 	/* 회원 탈퇴 */
-	void deleteUser(Long userId);
+	void deleteUser(Long userId, String refreshToken);
 
 }

--- a/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
@@ -32,6 +32,7 @@ import com.prgrms.mukvengers.domain.user.model.User;
 import com.prgrms.mukvengers.domain.user.repository.UserRepository;
 import com.prgrms.mukvengers.global.config.RestDocsConfig;
 import com.prgrms.mukvengers.global.security.token.service.JwtTokenProvider;
+import com.prgrms.mukvengers.global.security.token.service.TokenService;
 
 @SpringBootTest
 @Transactional
@@ -76,6 +77,9 @@ public abstract class ControllerTest {
 
 	@Autowired
 	protected ProposalRepository proposalRepository;
+
+	@Autowired
+	protected TokenService tokenService;
 
 	protected MockMvc mockMvc;
 

--- a/src/test/java/com/prgrms/mukvengers/base/ServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ServiceTest.java
@@ -24,6 +24,7 @@ import com.prgrms.mukvengers.domain.store.service.StoreService;
 import com.prgrms.mukvengers.domain.user.model.User;
 import com.prgrms.mukvengers.domain.user.repository.UserRepository;
 import com.prgrms.mukvengers.domain.user.service.UserService;
+import com.prgrms.mukvengers.global.security.token.service.TokenService;
 
 @SpringBootTest
 @Transactional
@@ -67,6 +68,9 @@ public abstract class ServiceTest {
 
 	@Autowired
 	protected ChatService chatService;
+
+	@Autowired
+	protected TokenService tokenService;
 
 	protected GeometryFactory gf = new GeometryFactory();
 

--- a/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
@@ -12,6 +12,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import javax.servlet.http.Cookie;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
@@ -162,7 +164,9 @@ class UserControllerTest extends ControllerTest {
 
 		// when
 		mockMvc.perform(delete("/api/v1/user/me")
-				.header(AUTHORIZATION, BEARER_TYPE + accessToken))
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken)
+				.cookie(new Cookie("refreshToken", tokenService.createRefreshToken(userId, "USER")))
+			)
 			// then
 			.andExpectAll(
 				handler().methodName("deleteMyProfile"),

--- a/src/test/java/com/prgrms/mukvengers/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/service/UserServiceTest.java
@@ -71,11 +71,21 @@ class UserServiceTest extends ServiceTest {
 		@DisplayName("[성공] userId를 통해서 사용자 정보를 삭제할 수 있다.")
 		void deleteUser_success() {
 			assertDoesNotThrow(
-				() -> userService.deleteUser(savedUser.getId())
+				() -> userService.deleteUser(savedUser.getId(), "refreshToken")
 			);
 			// 삭제 후 조회
-			assertThatThrownBy(() -> userService.getUserProfile(savedUser.getId()))
-				.isInstanceOf(UserNotFoundException.class);
+			var userProfile = userService.getUserProfile(savedUser.getId());
+
+			assertThat(userProfile)
+				.hasFieldOrPropertyWithValue("id", savedUser.getId())
+				.hasFieldOrPropertyWithValue("nickname", "탈퇴한 유저")
+				.hasFieldOrPropertyWithValue("profileImgUrl", "None")
+				.hasFieldOrPropertyWithValue("introduction", "탈퇴한 유저입니다.")
+				.hasFieldOrPropertyWithValue("leaderCount", 0)
+				.hasFieldOrPropertyWithValue("crewCount", 0)
+				.hasFieldOrPropertyWithValue("tasteScore", 0)
+				.hasFieldOrPropertyWithValue("mannerScore", "36.5")
+			;
 		}
 
 		@Test
@@ -87,7 +97,7 @@ class UserServiceTest extends ServiceTest {
 					.isInstanceOf(UserNotFoundException.class),
 				() -> assertThatThrownBy(() -> userService.updateUserProfile(getUpdateUserRequest(), UNSAVED_USER_ID))
 					.isInstanceOf(UserNotFoundException.class),
-				() -> assertThatThrownBy(() -> userService.deleteUser(UNSAVED_USER_ID))
+				() -> assertThatThrownBy(() -> userService.deleteUser(UNSAVED_USER_ID, "refreshToken"))
 					.isInstanceOf(UserNotFoundException.class)
 			);
 		}


### PR DESCRIPTION
### 🌱 작업 사항 
- 회원 탈퇴 기능을 구현했습니다.
- 소프트 딜리트를 적용했으나, 기존 방식과는 다르게 개인정보를 지우고 탈퇴한 회원으로 두었습니다.

### ❓ 리뷰 포인트
- 탈퇴한 회원으로 두는 것에 대해 어떻게 생각하시나요?
- 밥 모임에 속해 있는 경우 내보내는게 낫다고 생각하시나요?

### 🦄 관련 이슈
- resolves #232


