### PR TITLE
[#234] 메서드 실행 시간 측정 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/global/config/async/AsyncConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/async/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.prgrms.mukvengers.global.config.async;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import lombok.RequiredArgsConstructor;
+
+@EnableAsync
+@Configuration
+@RequiredArgsConstructor
+public class AsyncConfig implements AsyncConfigurer {
+
+	private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
+
+	@Override
+	public Executor getAsyncExecutor() {
+		return threadPoolTaskExecutor;
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/config/p6spy/P6spyConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/p6spy/P6spyConfig.java
@@ -1,6 +1,7 @@
 package com.prgrms.mukvengers.global.config.p6spy;
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
 
@@ -29,7 +30,7 @@ public class P6spyConfig implements MessageFormattingStrategy {
 
 		SimpleDateFormat formatter = new SimpleDateFormat("yy.MM.dd HH:mm:ss");
 
-		return formatter.format(currentDate) + " | " + "OperationTime : " + elapsed + "ms" + sql;
+		return category + " | " + "OperationTime : " + elapsed + "ms" + sql;
 	}
 
 	private String formatSql(String category, String sql) {
@@ -39,16 +40,21 @@ public class P6spyConfig implements MessageFormattingStrategy {
 
 		if (Category.STATEMENT.getName().equals(category)) {
 			String tmpsql = sql.trim().toLowerCase(Locale.ROOT);
-			if (tmpsql.startsWith("create") || tmpsql.startsWith("alter") || tmpsql.startsWith(
-				"comment")) {
+			if (tmpsql.startsWith("create") || tmpsql.startsWith("alter")) {
 				sql = FormatStyle.DDL.getFormatter().format(sql);
 			} else {
 				sql = FormatStyle.BASIC.getFormatter().format(sql);
 			}
-			sql = "|\n Hibernate FormatSql(P6Spy sql, Hibernate format): " + sql + "\n";
+			sql = "\n" + stackTrace() + "\n" + sql + "\n";
 		}
 
 		return sql;
+	}
+
+	private String stackTrace() {
+		return Arrays.toString(Arrays.stream(new Throwable().getStackTrace())
+			.filter(t -> t.toString().startsWith("com.prgrms.mukvengers"))
+			.toArray()).replace(", ", "\n");
 	}
 
 }

--- a/src/main/java/com/prgrms/mukvengers/global/config/scheduler/SchedulerConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/scheduler/SchedulerConfig.java
@@ -1,0 +1,27 @@
+package com.prgrms.mukvengers.global.config.scheduler;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@EnableScheduling
+@Configuration
+@ComponentScan(basePackages = "com.prgrms.mukvengers.global.scheduler")
+public class SchedulerConfig implements SchedulingConfigurer {
+
+	private static final int POOL_SIZE = 10;
+
+	@Override
+	public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+		ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+		threadPoolTaskScheduler.setPoolSize(POOL_SIZE);
+		threadPoolTaskScheduler.setThreadNamePrefix("scheduled-task-pool-");
+		threadPoolTaskScheduler.initialize();
+
+		taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+	}
+}
+

--- a/src/main/java/com/prgrms/mukvengers/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/security/SecurityConfig.java
@@ -10,17 +10,17 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
-import com.prgrms.mukvengers.global.security.token.filter.JwtAuthenticationEntryPoint;
-import com.prgrms.mukvengers.global.security.token.filter.JwtAuthenticationFilter;
-import com.prgrms.mukvengers.global.security.oauth.repository.HttpCookieOAuthAuthorizationRequestRepository;
 import com.prgrms.mukvengers.global.security.oauth.handler.OAuthAuthenticationFailureHandler;
 import com.prgrms.mukvengers.global.security.oauth.handler.OAuthAuthenticationSuccessHandler;
+import com.prgrms.mukvengers.global.security.oauth.repository.HttpCookieOAuthAuthorizationRequestRepository;
 import com.prgrms.mukvengers.global.security.token.exception.ExceptionHandlerFilter;
+import com.prgrms.mukvengers.global.security.token.filter.JwtAuthenticationEntryPoint;
+import com.prgrms.mukvengers.global.security.token.filter.JwtAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 
-@Configuration
 @EnableWebSecurity
+@Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/prgrms/mukvengers/global/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/websocket/WebSocketConfig.java
@@ -12,9 +12,9 @@ import com.prgrms.mukvengers.domain.chat.handler.StompHandler;
 
 import lombok.RequiredArgsConstructor;
 
+@EnableWebSocketMessageBroker
 @Configuration
 @RequiredArgsConstructor
-@EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	private final StompHandler stompHandler;

--- a/src/main/java/com/prgrms/mukvengers/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/mukvengers/global/exception/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.prgrms.mukvengers.global.common.dto.ErrorResponse;
-import com.prgrms.mukvengers.global.slack.annotation.SlackNotification;
+import com.prgrms.mukvengers.global.report.annotation.SlackNotification;
 import com.prgrms.mukvengers.global.utils.MessageUtil;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/prgrms/mukvengers/global/log/LoggingAspect.java
+++ b/src/main/java/com/prgrms/mukvengers/global/log/LoggingAspect.java
@@ -1,0 +1,39 @@
+package com.prgrms.mukvengers.global.log;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+// @Profile("performance")
+public class LoggingAspect {
+
+	@Pointcut("execution(* com.prgrms.mukvengers.domain..*(..))")
+	public void methodInDomain() {
+	}
+
+	// 메서드 실행시간 분석
+	@Around("methodInDomain()")
+	public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+		long startTime = System.currentTimeMillis();
+		Object result = joinPoint.proceed();
+		long endTime = System.currentTimeMillis();
+
+		long executionTimeMillis = endTime - startTime;
+
+		Signature signature = joinPoint.getSignature();
+
+		String methodName = signature.getName();
+		String className = signature.getDeclaringType().getSimpleName();
+		log.info("[ExecutionTime] : {}.{} took {}ms", className, methodName, executionTimeMillis);
+
+		return result;
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/report/SlackNotificationAspect.java
+++ b/src/main/java/com/prgrms/mukvengers/global/report/SlackNotificationAspect.java
@@ -1,4 +1,4 @@
-package com.prgrms.mukvengers.global.slack;
+package com.prgrms.mukvengers.global.report;
 
 import static java.util.Collections.*;
 
@@ -23,7 +23,7 @@ import net.gpedro.integrations.slack.SlackAttachment;
 import net.gpedro.integrations.slack.SlackField;
 import net.gpedro.integrations.slack.SlackMessage;
 
-import com.prgrms.mukvengers.global.slack.dto.RequestInfo;
+import com.prgrms.mukvengers.global.report.dto.RequestInfo;
 
 @Aspect
 @Component
@@ -40,7 +40,7 @@ public class SlackNotificationAspect {
 		this.env = env;
 	}
 
-	@Around("@annotation(com.prgrms.mukvengers.global.slack.annotation.SlackNotification) && args(request, e)")
+	@Around("@annotation(com.prgrms.mukvengers.global.report.annotation.SlackNotification) && args(request, e)")
 	public void slackNotificate(ProceedingJoinPoint proceedingJoinPoint, HttpServletRequest request,
 		Exception e) throws Throwable {
 

--- a/src/main/java/com/prgrms/mukvengers/global/report/annotation/SlackNotification.java
+++ b/src/main/java/com/prgrms/mukvengers/global/report/annotation/SlackNotification.java
@@ -1,4 +1,4 @@
-package com.prgrms.mukvengers.global.slack.annotation;
+package com.prgrms.mukvengers.global.report.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/prgrms/mukvengers/global/report/dto/RequestInfo.java
+++ b/src/main/java/com/prgrms/mukvengers/global/report/dto/RequestInfo.java
@@ -1,4 +1,4 @@
-package com.prgrms.mukvengers.global.slack.dto;
+package com.prgrms.mukvengers.global.report.dto;
 
 import javax.servlet.http.HttpServletRequest;
 

--- a/src/main/java/com/prgrms/mukvengers/global/scheduler/CrewScheduler.java
+++ b/src/main/java/com/prgrms/mukvengers/global/scheduler/CrewScheduler.java
@@ -3,37 +3,24 @@ package com.prgrms.mukvengers.global.scheduler;
 import java.time.LocalDateTime;
 
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
-import com.prgrms.mukvengers.domain.proposal.repository.ProposalRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
-@EnableAsync
-@EnableScheduling
 @RequiredArgsConstructor
-public class Scheduler {
+public class CrewScheduler {
 
 	private final CrewRepository crewRepository;
-	private final ProposalRepository proposalRepository;
 
 	@Async
 	@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void changStatusOvertimeCrew() {
 		crewRepository.updateAllStatusToFinish(LocalDateTime.now());
-	}
-
-	@Async
-	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-	@Transactional
-	public void deleteProposalOverTimeCrew() {
-		proposalRepository.deleteProposalsByPromiseTime(LocalDateTime.now());
 	}
 }

--- a/src/main/java/com/prgrms/mukvengers/global/scheduler/ProposalScheduler.java
+++ b/src/main/java/com/prgrms/mukvengers/global/scheduler/ProposalScheduler.java
@@ -1,0 +1,26 @@
+package com.prgrms.mukvengers.global.scheduler;
+
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.mukvengers.domain.proposal.repository.ProposalRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProposalScheduler {
+
+	private final ProposalRepository proposalRepository;
+
+	@Async
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	@Transactional
+	public void deleteProposalOverTimeCrew() {
+		proposalRepository.deleteProposalsByPromiseTime(LocalDateTime.now());
+	}
+}

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -1,9 +1,3 @@
-spring:
-  servlet:
-    multipart:
-      max-request-size: 10MB
-      max-file-size: 10MB
-
 cloud:
   aws:
     s3:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,8 +15,7 @@ spring:
     include:
       - db
       - security
-      - aws
-      - slack
+      - cloud
   # ResourceHandler 설정 (Static Resource Mapping)
   web:
     resources:
@@ -25,6 +24,11 @@ spring:
   messages:
     encoding: UTF-8
     basename: messages/exceptions/exception, messages/notification/messages
+
+  servlet:
+    multipart:
+      max-request-size: 10MB
+      max-file-size: 10MB
 
   slack:
     webhook: ${SLACK_WEBHOOK}

--- a/src/test/java/com/prgrms/mukvengers/global/report/SlackNotificationAspectTest.java
+++ b/src/test/java/com/prgrms/mukvengers/global/report/SlackNotificationAspectTest.java
@@ -1,4 +1,4 @@
-package com.prgrms.mukvengers.global.slack;
+package com.prgrms.mukvengers.global.report;
 
 import static org.mockito.BDDMockito.*;
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,4 +3,4 @@ spring:
     include:
       - test
       - security
-      - aws
+      - cloud


### PR DESCRIPTION
### 🌱 작업 사항 
- 메서드 실행시간 측정 및 쿼리 문 까지의 stackTrace를 볼 수 있도록 개선했습니다!
- 07.20 회의를 통해 좀 더 얘기를 나누고 피드백을 적용한 후에 머지하겠습니다.
  - 자세한 변경 내역에 대해서는 라이브로 설명하겠습니다.

### 실행 시간 측정

![image](https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-BE/assets/99165624/fa1069cd-f74c-4fd8-bf72-b8bded043611)

- 참고로 메서드간의 포함 관계가 있기 때문에 레포지토리 동작은 72ms, 서비스 동작은 91 -72 = 19ms 생각하면 됩니다.

### 쿼리가 실행되기 까지의 StackTrace

![image](https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-BE/assets/99165624/35b9c4fd-f4a0-4dfb-b5a4-93547e15aa90)

- 쿼리 자체 시간은 11ms 입니다.

### ❓ 리뷰 포인트
- 패키지 명을 바꿨는데 어떻게 생각하시나요?
- 성능 로깅 말고 로깅을 활용할 수 있는 아이디어가 있다면 알려주세요!
### 🦄 관련 이슈
- resolves #234 



